### PR TITLE
refactor(admin): audit super-admin writes + UX loading skeletons

### DIFF
--- a/app/[locale]/(app)/ballons/loading.tsx
+++ b/app/[locale]/(app)/ballons/loading.tsx
@@ -1,0 +1,27 @@
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-9 w-40" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 py-2">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-28 flex-1" />
+              <Skeleton className="h-5 w-20" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/[locale]/(app)/billets/loading.tsx
+++ b/app/[locale]/(app)/billets/loading.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-9 w-40" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 py-2">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-5 w-40 flex-1" />
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-24" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/[locale]/(app)/pilotes/loading.tsx
+++ b/app/[locale]/(app)/pilotes/loading.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-9 w-40" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 py-2">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-5 w-28 flex-1" />
+              <Skeleton className="h-5 w-20" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/[locale]/(app)/vols/loading.tsx
+++ b/app/[locale]/(app)/vols/loading.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-9 w-40" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      <div className="md:hidden space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <CardContent className="p-4 space-y-3">
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-4 w-2/3" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="hidden md:block">
+        <Card>
+          <CardContent className="p-4">
+            <div className="grid grid-cols-7 gap-3">
+              {Array.from({ length: 14 }).map((_, i) => (
+                <Skeleton key={i} className="h-24" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,11 +24,13 @@ const config = [
     ],
   },
 
-  // adminDb import restriction: only lib/admin/**, app/**/admin/**, scripts/**, prisma/seed.ts
+  // adminDb import restriction: only lib/admin/**, lib/actions/admin.ts,
+  // app/**/admin/**, scripts/**, prisma/seed.ts
   {
     files: ['**/*.ts', '**/*.tsx'],
     ignores: [
       'lib/admin/**',
+      'lib/actions/admin.ts',
       'app/**/admin/**',
       'lib/db/**',
       'scripts/**',

--- a/lib/actions/admin.ts
+++ b/lib/actions/admin.ts
@@ -2,23 +2,19 @@
 
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
+import { adminDb } from '@/lib/db'
 import { basePrisma } from '@/lib/db/base'
 import { revalidatePath } from 'next/cache'
-import { ForbiddenError } from '@/lib/errors'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireRole } from '@/lib/auth/requireRole'
 import { sendInvitationEmail } from '@/lib/email/invitation'
 
-async function requireAdminCalpax() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session?.user) throw new ForbiddenError()
-  const user = session.user as Record<string, unknown>
-  if (user.role !== 'ADMIN_CALPAX') throw new ForbiddenError()
-  return session.user
-}
-
 export async function revokeSession(sessionId: string) {
-  await requireAdminCalpax()
-  await basePrisma.session.delete({ where: { id: sessionId } })
-  revalidatePath('/admin/sessions')
+  return requireAuth(async () => {
+    requireRole('ADMIN_CALPAX')
+    await adminDb.session.delete({ where: { id: sessionId } })
+    revalidatePath('/admin/sessions')
+  })
 }
 
 export async function fetchAdminAuditLogs(filters: {
@@ -27,23 +23,25 @@ export async function fetchAdminAuditLogs(filters: {
   action?: string
   page?: number
 }) {
-  await requireAdminCalpax()
+  return requireAuth(async () => {
+    requireRole('ADMIN_CALPAX')
 
-  const page = filters.page ?? 1
-  const take = 50
-  const skip = (page - 1) * take
+    const page = filters.page ?? 1
+    const take = 50
+    const skip = (page - 1) * take
 
-  const where: Record<string, unknown> = {}
-  if (filters.exploitantId) where.exploitantId = filters.exploitantId
-  if (filters.entityType) where.entityType = filters.entityType
-  if (filters.action) where.action = filters.action
+    const where: Record<string, unknown> = {}
+    if (filters.exploitantId) where.exploitantId = filters.exploitantId
+    if (filters.entityType) where.entityType = filters.entityType
+    if (filters.action) where.action = filters.action
 
-  const [logs, total] = await Promise.all([
-    basePrisma.auditLog.findMany({ where, orderBy: { createdAt: 'desc' }, take, skip }),
-    basePrisma.auditLog.count({ where }),
-  ])
+    const [logs, total] = await Promise.all([
+      basePrisma.auditLog.findMany({ where, orderBy: { createdAt: 'desc' }, take, skip }),
+      basePrisma.auditLog.count({ where }),
+    ])
 
-  return { logs, total, page, pageCount: Math.ceil(total / take) }
+    return { logs, total, page, pageCount: Math.ceil(total / take) }
+  })
 }
 
 export async function createUserForExploitant(data: {
@@ -52,51 +50,53 @@ export async function createUserForExploitant(data: {
   exploitantId: string
   role: string
 }) {
-  await requireAdminCalpax()
+  return requireAuth(async () => {
+    requireRole('ADMIN_CALPAX')
 
-  // Generate a random password the user will never see.
-  // The user will receive a password reset email and set their own password.
-  const { hashPassword } = await import('better-auth/crypto')
-  const randomPassword = crypto.randomUUID() + crypto.randomUUID()
-  const hashedPassword = await hashPassword(randomPassword)
+    // Generate a random password the user will never see.
+    // The user will receive a password reset email and set their own password.
+    const { hashPassword } = await import('better-auth/crypto')
+    const randomPassword = crypto.randomUUID() + crypto.randomUUID()
+    const hashedPassword = await hashPassword(randomPassword)
 
-  // emailVerified is set to true intentionally: admin-created users are vouched
-  // for by the admin. The user will still receive a password reset email (below)
-  // and must set their own password before they can sign in.
-  // Self-signup (public) goes through Better Auth directly, which enforces
-  // email verification via `emailAndPassword.requireEmailVerification` in lib/auth.ts.
-  const user = await basePrisma.user.create({
-    data: {
-      email: data.email,
-      name: data.name,
-      exploitantId: data.exploitantId,
-      role: data.role as 'GERANT' | 'PILOTE' | 'EQUIPIER',
-      emailVerified: true,
-      accounts: {
-        create: {
-          accountId: data.email,
-          providerId: 'credential',
-          password: hashedPassword,
+    // emailVerified is set to true intentionally: admin-created users are vouched
+    // for by the admin. The user will still receive a password reset email (below)
+    // and must set their own password before they can sign in.
+    // Self-signup (public) goes through Better Auth directly, which enforces
+    // email verification via `emailAndPassword.requireEmailVerification` in lib/auth.ts.
+    const user = await adminDb.user.create({
+      data: {
+        email: data.email,
+        name: data.name,
+        exploitantId: data.exploitantId,
+        role: data.role as 'GERANT' | 'PILOTE' | 'EQUIPIER',
+        emailVerified: true,
+        accounts: {
+          create: {
+            accountId: data.email,
+            providerId: 'credential',
+            password: hashedPassword,
+          },
         },
       },
-    },
-    include: {
-      exploitant: { select: { name: true } },
-    },
-  })
+      include: {
+        exploitant: { select: { name: true } },
+      },
+    })
 
-  // Send a "welcome to Calpax" invitation email (distinct from a password reset).
-  // This generates a reset-password verification token under the hood so the user
-  // can set their own password, but the email copy is written for a brand-new user.
-  const invitationResult = await sendInvitationEmail({
-    userId: user.id,
-    email: user.email,
-    name: user.name,
-    exploitantName: user.exploitant?.name ?? '',
-  })
+    // Send a "welcome to Calpax" invitation email (distinct from a password reset).
+    // This generates a reset-password verification token under the hood so the user
+    // can set their own password, but the email copy is written for a brand-new user.
+    const invitationResult = await sendInvitationEmail({
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      exploitantName: user.exploitant?.name ?? '',
+    })
 
-  revalidatePath('/admin/invitations')
-  return { user, emailSent: invitationResult.sent }
+    revalidatePath('/admin/invitations')
+    return { user, emailSent: invitationResult.sent }
+  })
 }
 
 /**
@@ -111,25 +111,27 @@ export async function toggleUserBan(args: {
   banned: boolean
   reason?: string
 }): Promise<{ error?: string }> {
-  await requireAdminCalpax()
+  return requireAuth(async () => {
+    requireRole('ADMIN_CALPAX')
 
-  try {
-    if (args.banned) {
-      await auth.api.banUser({
-        headers: await headers(),
-        body: { userId: args.userId, banReason: args.reason ?? 'Désactivé par un administrateur' },
-      })
-    } else {
-      await auth.api.unbanUser({
-        headers: await headers(),
-        body: { userId: args.userId },
-      })
+    try {
+      if (args.banned) {
+        await auth.api.banUser({
+          headers: await headers(),
+          body: { userId: args.userId, banReason: args.reason ?? 'Désactivé par un administrateur' },
+        })
+      } else {
+        await auth.api.unbanUser({
+          headers: await headers(),
+          body: { userId: args.userId },
+        })
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Opération refusée'
+      return { error: msg }
     }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Opération refusée'
-    return { error: msg }
-  }
 
-  revalidatePath('/admin/users')
-  return {}
+    revalidatePath('/admin/users')
+    return {}
+  })
 }


### PR DESCRIPTION
## Summary

Outcome of a full-codebase sweep (simplification, quality, security, RGPD, UX). Two concrete fixes shipped; the rest are notes in this PR body for follow-up.

### 1. Security + audit fix — `lib/actions/admin.ts`

Super-admin server actions (`revokeSession`, `createUserForExploitant`) wrote through `basePrisma`, which **bypasses the audit extension**. These privileged actions were silent in the audit log — a RGPD art. 30 gap.

- Replace bespoke `requireAdminCalpax()` with `requireAuth(async () => { requireRole('ADMIN_CALPAX'); ... })`, matching the convention used across every other `lib/actions/*.ts` (documented in CLAUDE.md).
- Route writes through `adminDb` (which is `basePrisma.$extends(auditExtension)`), so CREATE/DELETE by super-admins are now logged with proper `userId`/`exploitantId` via `AsyncLocalStorage` context.
- Audit-log **reads** stay on `basePrisma` (reads aren't audited).

### 2. UX — `loading.tsx` for `vols` / `billets` / `pilotes` / `ballons`

Next.js App Router streams skeletons while the server resolves DB queries — immediate feedback on cold loads, no new abstraction.

## Findings the PR does **not** fix (worth discussing)

- **`toggleUserBan`** still calls Better Auth's internal `api.banUser`, which writes via Better Auth's own Prisma client and bypasses `auditExtension`. Consider emitting an explicit `basePrisma.auditLog.create` after ban succeeds so the only remaining admin write is captured.
- **`lib/actions/rgpd.ts:searchPassagers`** uses `basePrisma.$queryRaw` with a hand-written `exploitantId` filter. Safe (parameterized), but switching to `db.passager.findMany({ where: { OR: [...] } })` would let the tenant extension enforce isolation — removes a footgun for future contributors.
- **`Passager.email` / `Passager.telephone`** stored plaintext. Redacted in audit logs but searchable in clear at rest. RGPD art. 32 suggests encrypting — schema migration, out of scope here.
- **Empty states**: `components/empty-state.tsx` isn't used consistently on list pages (bare table on zero rows).
- **Billet multi-step form** lacks a progress indicator.
- **CAMO/BFCL expiration badges** could live in a persistent top-bar for visibility from any page.
- **Impersonation banner** — verify it's sticky + high-contrast when `impersonatedBy` is set.

## Test plan

- [ ] `npm run typecheck` passes (confirmed locally — only pre-existing `tsconfig baseUrl` deprecation)
- [ ] Connect as `ADMIN_CALPAX`, revoke a session, create an invitation → check `/admin/audit` shows the new rows attributed to the admin
- [ ] Connect as `GERANT` → try the admin server actions → confirm `ForbiddenError`
- [ ] Throttle network, open `/vols`, `/billets`, `/pilotes`, `/ballons` → skeletons appear before content
- [ ] Run `npm run test` + `npm run test:integration`

https://claude.ai/code/session_01TCaXkWuytpxkvQDYb8czd4