### PR TITLE
UI/UX pass: i18n, dashboard, login, cross-app consistency

### DIFF
--- a/app/[locale]/(app)/ballons/[id]/edit/ballon-edit-form.tsx
+++ b/app/[locale]/(app)/ballons/[id]/edit/ballon-edit-form.tsx
@@ -15,8 +15,7 @@ import { PerformanceChartInput } from '@/components/performance-chart-input'
 import { ConfigGazInput } from '@/components/config-gaz-input'
 import { updateBallon, toggleBallonActif } from '@/lib/actions/ballon'
 import { cn } from '@/lib/utils'
-
-const labelClassName = 'text-xs font-medium uppercase tracking-wider text-muted-foreground'
+import { formLabelClass as labelClassName } from '@/lib/ui'
 
 type Props = {
   locale: string

--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -197,7 +197,7 @@ export default async function HomePage({ params }: Props) {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+            <h1 className="text-3xl font-bold tracking-tight">{t('title')}</h1>
             <p className="text-sm text-muted-foreground">
               {today.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-US', {
                 weekday: 'long',

--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -224,7 +224,7 @@ export default async function HomePage({ params }: Props) {
         ) : (
           <div className="grid gap-4 sm:grid-cols-2">
             {cards.map((card) => (
-              <FlightCard key={card.id} flight={card} locale={locale} />
+              <FlightCard key={card.id} flight={card} locale={locale} userRole={ctx.role} />
             ))}
           </div>
         )}

--- a/app/[locale]/(app)/pilotes/[id]/edit/pilote-edit-form.tsx
+++ b/app/[locale]/(app)/pilotes/[id]/edit/pilote-edit-form.tsx
@@ -11,8 +11,7 @@ import { Button, buttonVariants } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { updatePilote } from '@/lib/actions/pilote'
 import { cn } from '@/lib/utils'
-
-const labelClassName = 'text-xs font-medium uppercase tracking-wider text-muted-foreground'
+import { formLabelClass as labelClassName } from '@/lib/ui'
 
 type Props = {
   locale: string

--- a/app/[locale]/(app)/vols/create/vol-create-form.tsx
+++ b/app/[locale]/(app)/vols/create/vol-create-form.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/select'
 import { createVol, updateVol } from '@/lib/actions/vol'
 import { cn } from '@/lib/utils'
+import { formLabelClass as labelClassName } from '@/lib/ui'
 
 type BallonOption = {
   id: string
@@ -73,8 +74,6 @@ type Props = {
 }
 
 const CRENEAU_OPTIONS = ['MATIN', 'SOIR'] as const
-
-const labelClassName = 'text-xs font-medium uppercase tracking-wider text-muted-foreground'
 
 export function VolCreateForm({
   locale,

--- a/app/[locale]/(app)/vols/page.tsx
+++ b/app/[locale]/(app)/vols/page.tsx
@@ -131,7 +131,12 @@ export default async function VolsPage({ params, searchParams }: Props) {
         {/* Mobile: stacked flight cards */}
         <div className="md:hidden space-y-3">
           {volsRaw.map((vol) => (
-            <FlightCard key={vol.id} flight={mapVolToCardData(vol)} locale={locale} />
+            <FlightCard
+              key={vol.id}
+              flight={mapVolToCardData(vol)}
+              locale={locale}
+              userRole={ctx.role}
+            />
           ))}
           {volsRaw.length === 0 && (
             <p className="text-center text-muted-foreground py-8">{t('noVols')}</p>

--- a/app/[locale]/auth/reset-password/page.tsx
+++ b/app/[locale]/auth/reset-password/page.tsx
@@ -88,6 +88,8 @@ export default function ResetPasswordPage() {
                 id="new-password"
                 name="newPassword"
                 type="password"
+                autoComplete="new-password"
+                autoFocus
                 required
                 minLength={12}
                 value={newPassword}
@@ -108,6 +110,7 @@ export default function ResetPasswordPage() {
                 id="confirm-password"
                 name="confirmPassword"
                 type="password"
+                autoComplete="new-password"
                 required
                 minLength={12}
                 value={confirmPassword}

--- a/app/[locale]/auth/reset-password/page.tsx
+++ b/app/[locale]/auth/reset-password/page.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { authClient } from '@/lib/auth-client'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { toast } from 'sonner'
+import { Eye, EyeOff, Loader2, X } from 'lucide-react'
 import { PasswordStrength } from '@/components/password-strength'
 
 export default function ResetPasswordPage() {
@@ -15,6 +17,7 @@ export default function ResetPasswordPage() {
 
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [success, setSuccess] = useState(false)
@@ -36,6 +39,7 @@ export default function ResetPasswordPage() {
         newPassword,
         token,
       })
+      toast.success(isInvitation ? t('invitationSuccess') : t('passwordResetSuccess'))
       setSuccess(true)
     } catch {
       setError(t('resetError'))
@@ -57,8 +61,16 @@ export default function ResetPasswordPage() {
         </h2>
 
         {error && (
-          <div className="mb-4 rounded-lg bg-destructive/10 px-4 py-2.5 text-sm text-destructive">
-            {error}
+          <div className="mb-4 rounded-lg bg-destructive/10 px-4 py-2.5 text-sm text-destructive flex items-start justify-between gap-2">
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={() => setError(null)}
+              aria-label="Dismiss"
+              className="text-destructive/70 hover:text-destructive"
+            >
+              <X className="h-4 w-4" />
+            </button>
           </div>
         )}
 
@@ -84,19 +96,29 @@ export default function ResetPasswordPage() {
               >
                 {t('newPasswordLabel')}
               </label>
-              <input
-                id="new-password"
-                name="newPassword"
-                type="password"
-                autoComplete="new-password"
-                autoFocus
-                required
-                minLength={12}
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-                placeholder={t('newPasswordPlaceholder')}
-                className="w-full bg-secondary/30 border border-border rounded-lg px-3 py-2.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
-              />
+              <div className="relative">
+                <input
+                  id="new-password"
+                  name="newPassword"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  autoFocus
+                  required
+                  minLength={12}
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  placeholder={t('newPasswordPlaceholder')}
+                  className="w-full bg-secondary/30 border border-border rounded-lg px-3 py-2.5 pr-10 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((s) => !s)}
+                  aria-label={showPassword ? t('hidePassword') : t('showPassword')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground"
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
               <PasswordStrength password={newPassword} minLength={12} />
             </div>
             <div className="space-y-1.5">
@@ -109,7 +131,7 @@ export default function ResetPasswordPage() {
               <input
                 id="confirm-password"
                 name="confirmPassword"
-                type="password"
+                type={showPassword ? 'text' : 'password'}
                 autoComplete="new-password"
                 required
                 minLength={12}
@@ -118,13 +140,17 @@ export default function ResetPasswordPage() {
                 placeholder={t('confirmPasswordPlaceholder')}
                 className="w-full bg-secondary/30 border border-border rounded-lg px-3 py-2.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
               />
+              {confirmPassword && newPassword && confirmPassword !== newPassword && (
+                <p className="text-[11px] text-destructive">{t('passwordMismatch')}</p>
+              )}
             </div>
             <button
               type="submit"
               disabled={loading}
-              className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+              className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center justify-center gap-2"
             >
-              {loading ? '...' : isInvitation ? t('invitationButton') : t('resetPasswordButton')}
+              {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+              {isInvitation ? t('invitationButton') : t('resetPasswordButton')}
             </button>
           </form>
         )}

--- a/app/[locale]/auth/signin/page.tsx
+++ b/app/[locale]/auth/signin/page.tsx
@@ -24,13 +24,13 @@ export default function SignInPage() {
     try {
       const result = await signIn.email({ email, password })
       if (result.error) {
-        setError(result.error.message ?? 'Erreur de connexion')
+        setError(result.error.message ?? t('loginError'))
       } else {
         router.push('/')
         router.refresh()
       }
     } catch {
-      setError('Erreur de connexion')
+      setError(t('loginError'))
     } finally {
       setLoading(false)
     }
@@ -174,6 +174,8 @@ export default function SignInPage() {
                     id="email"
                     name="email"
                     type="email"
+                    autoComplete="email"
+                    autoFocus
                     required
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
@@ -192,6 +194,7 @@ export default function SignInPage() {
                     id="password"
                     name="password"
                     type="password"
+                    autoComplete="current-password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
@@ -272,6 +275,8 @@ export default function SignInPage() {
                     id="forgot-email"
                     name="email"
                     type="email"
+                    autoComplete="email"
+                    autoFocus
                     required
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}

--- a/app/[locale]/auth/signin/page.tsx
+++ b/app/[locale]/auth/signin/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { authClient, signIn } from '@/lib/auth-client'
 import { useRouter } from 'next/navigation'
+import { Eye, EyeOff, Loader2, X } from 'lucide-react'
 
 type Mode = 'signin' | 'forgot'
 
@@ -12,6 +13,7 @@ export default function SignInPage() {
   const router = useRouter()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [mode, setMode] = useState<Mode>('signin')
@@ -137,8 +139,16 @@ export default function SignInPage() {
           </h2>
 
           {error && (
-            <div className="mb-4 w-full max-w-xs rounded-lg bg-destructive/10 px-4 py-2.5 text-sm text-destructive">
-              {error}
+            <div className="mb-4 w-full max-w-xs rounded-lg bg-destructive/10 px-4 py-2.5 text-sm text-destructive flex items-start justify-between gap-2">
+              <span>{error}</span>
+              <button
+                type="button"
+                onClick={() => setError(null)}
+                aria-label="Dismiss"
+                className="text-destructive/70 hover:text-destructive"
+              >
+                <X className="h-4 w-4" />
+              </button>
             </div>
           )}
 
@@ -190,17 +200,31 @@ export default function SignInPage() {
                   >
                     {t('passwordLabel')}
                   </label>
-                  <input
-                    id="password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
-                    required
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    placeholder={t('passwordPlaceholder')}
-                    className="w-full bg-secondary/30 border border-border rounded-lg px-3 py-2.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
-                  />
+                  <div className="relative">
+                    <input
+                      id="password"
+                      name="password"
+                      type={showPassword ? 'text' : 'password'}
+                      autoComplete="current-password"
+                      required
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      placeholder={t('passwordPlaceholder')}
+                      className="w-full bg-secondary/30 border border-border rounded-lg px-3 py-2.5 pr-10 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((s) => !s)}
+                      aria-label={showPassword ? t('hidePassword') : t('showPassword')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground"
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
                 </div>
                 <div className="text-right">
                   <button
@@ -217,9 +241,10 @@ export default function SignInPage() {
                 <button
                   type="submit"
                   disabled={loading}
-                  className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+                  className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center justify-center gap-2"
                 >
-                  {loading ? '...' : t('submit')}
+                  {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+                  {t('submit')}
                 </button>
               </form>
 
@@ -287,9 +312,10 @@ export default function SignInPage() {
                 <button
                   type="submit"
                   disabled={loading}
-                  className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+                  className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center justify-center gap-2"
                 >
-                  {loading ? '...' : t('sendResetLink')}
+                  {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+                  {t('sendResetLink')}
                 </button>
               </form>
               <button

--- a/app/[locale]/auth/verify/page.tsx
+++ b/app/[locale]/auth/verify/page.tsx
@@ -1,13 +1,31 @@
 import { getTranslations } from 'next-intl/server'
+import Link from 'next/link'
 
-export default async function VerifyPage() {
+type Props = {
+  params: Promise<{ locale: string }>
+}
+
+export default async function VerifyPage({ params }: Props) {
+  const { locale } = await params
   const t = await getTranslations('signin')
 
   return (
-    <main className="min-h-screen flex items-center justify-center">
-      <div className="w-full max-w-sm space-y-4 p-8 text-center">
-        <h1 className="text-2xl font-bold">{t('verifyTitle')}</h1>
-        <p className="text-muted-foreground">{t('verifySent')}</p>
+    <main className="min-h-screen flex items-center justify-center bg-[#E8ECF0] p-4">
+      <div className="w-full max-w-md rounded-2xl shadow-xl bg-white px-8 py-12 text-center">
+        <div className="flex flex-col items-center mb-8">
+          <img src="/logo.svg" alt="Calpax" className="h-12 w-12" />
+          <h1 className="text-[26px] font-bold text-primary mt-3">Calpax</h1>
+        </div>
+
+        <h2 className="text-[18px] font-semibold text-foreground mb-3">{t('verifyTitle')}</h2>
+        <p className="text-sm text-muted-foreground mb-8">{t('verifySent')}</p>
+
+        <Link
+          href={`/${locale}/auth/signin`}
+          className="inline-block text-sm text-primary hover:underline"
+        >
+          {t('backToSignin')}
+        </Link>
       </div>
     </main>
   )

--- a/components/change-password-form.tsx
+++ b/components/change-password-form.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { Loader2 } from 'lucide-react'
 import { PasswordStrength } from '@/components/password-strength'
 import { formLabelClass } from '@/lib/ui'
 
@@ -101,7 +102,8 @@ export function ChangePasswordForm() {
             />
           </div>
           <Button type="submit" disabled={loading} className="w-full sm:w-auto">
-            {loading ? '...' : t('changePasswordButton')}
+            {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+            {t('changePasswordButton')}
           </Button>
         </form>
       </CardContent>

--- a/components/change-password-form.tsx
+++ b/components/change-password-form.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { PasswordStrength } from '@/components/password-strength'
+import { formLabelClass } from '@/lib/ui'
 
 export function ChangePasswordForm() {
   const t = useTranslations('profil')
@@ -54,7 +55,7 @@ export function ChangePasswordForm() {
           <div className="space-y-1.5">
             <Label
               htmlFor="current-password"
-              className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+              className={formLabelClass}
             >
               {t('currentPassword')}
             </Label>
@@ -69,7 +70,7 @@ export function ChangePasswordForm() {
           <div className="space-y-1.5">
             <Label
               htmlFor="new-password"
-              className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+              className={formLabelClass}
             >
               {t('newPassword')}
             </Label>
@@ -86,7 +87,7 @@ export function ChangePasswordForm() {
           <div className="space-y-1.5">
             <Label
               htmlFor="confirm-password"
-              className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+              className={formLabelClass}
             >
               {t('confirmPassword')}
             </Label>

--- a/components/flight-card.tsx
+++ b/components/flight-card.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
-import { Users, Wind, Thermometer, AlertTriangle } from 'lucide-react'
+import { Wind, Thermometer, AlertTriangle } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import type { UserRole } from '@/lib/context'
 
 type MassBudget = {
   totalWeight: number
@@ -41,6 +42,16 @@ type Props = {
   flight: FlightCardData
   locale: string
   showActions?: boolean
+  userRole?: UserRole
+}
+
+const CAN_ORGANIZE: UserRole[] = ['ADMIN_CALPAX', 'GERANT']
+
+function capacityColorClass(count: number, max: number): string {
+  if (max === 0) return ''
+  if (count > max) return 'text-red-600'
+  if (count / max >= 0.8) return 'text-amber-600'
+  return 'text-green-700'
 }
 
 type BadgeVariant = 'outline' | 'secondary' | 'default' | 'destructive' | 'warning'
@@ -77,9 +88,10 @@ const GONOGO_VARIANT: Record<WeatherSummary['goNogo'], BadgeVariant> = {
   MARGINAL: 'warning',
 }
 
-export function FlightCard({ flight, locale, showActions = true }: Props) {
+export function FlightCard({ flight, locale, showActions = true, userRole }: Props) {
   const t = useTranslations('dashboard')
   const tv = useTranslations('vols')
+  const canOrganize = userRole ? CAN_ORGANIZE.includes(userRole) : true
 
   return (
     <Card className={cn(flight.meteoAlert && 'border-amber-400 bg-amber-50/50')}>
@@ -114,7 +126,12 @@ export function FlightCard({ flight, locale, showActions = true }: Props) {
           </div>
           <div>
             <span className="text-xs text-muted-foreground">{t('capacity')}</span>
-            <p className="font-medium">
+            <p
+              className={cn(
+                'font-medium',
+                capacityColorClass(flight.passagerCount, flight.passagerMax),
+              )}
+            >
               {flight.passagerCount}/{flight.passagerMax}
             </p>
           </div>
@@ -137,31 +154,36 @@ export function FlightCard({ flight, locale, showActions = true }: Props) {
 
         {/* Weather */}
         {flight.weather && (
-          <div className="flex items-center gap-4 text-sm rounded-md bg-muted/50 px-3 py-2 flex-wrap">
-            <span className="text-muted-foreground">
-              {tv(`creneau.${flight.creneau}`)} ({flight.weather.creneauRange})
-            </span>
-            <div className="flex items-center gap-1">
-              <Wind className="h-3.5 w-3.5 text-muted-foreground" />
-              <span>
-                {flight.weather.maxWindKt} km/h ({flight.weather.maxWindAltitude})
+          <div
+            className={cn(
+              'rounded-md px-3 py-2 text-sm space-y-1.5',
+              flight.meteoAlert ? 'bg-amber-100' : 'bg-muted/50',
+            )}
+          >
+            <div className="flex items-center gap-4 flex-wrap">
+              <span className="text-muted-foreground">
+                {tv(`creneau.${flight.creneau}`)} ({flight.weather.creneauRange})
               </span>
+              <div className="flex items-center gap-1">
+                <Wind className="h-4 w-4 text-muted-foreground" />
+                <span>
+                  {flight.weather.maxWindKt} km/h ({flight.weather.maxWindAltitude})
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Thermometer className="h-4 w-4 text-muted-foreground" />
+                <span>{flight.weather.avgTemperature}°C</span>
+              </div>
+              <Badge variant={GONOGO_VARIANT[flight.weather.goNogo]}>
+                {t(`goNogo.${flight.weather.goNogo}`)}
+              </Badge>
             </div>
-            <div className="flex items-center gap-1">
-              <Thermometer className="h-3.5 w-3.5 text-muted-foreground" />
-              <span>{flight.weather.avgTemperature}°C</span>
-            </div>
-            <Badge variant={GONOGO_VARIANT[flight.weather.goNogo]}>
-              {t(`goNogo.${flight.weather.goNogo}`)}
-            </Badge>
-          </div>
-        )}
-
-        {/* Meteo alert */}
-        {flight.meteoAlert && (
-          <div className="flex items-center gap-2 rounded-md bg-amber-100 px-3 py-2 text-sm text-amber-800">
-            <AlertTriangle className="h-4 w-4 shrink-0" />
-            <span>{t('meteoAlert')}</span>
+            {flight.meteoAlert && (
+              <div className="flex items-center gap-2 text-amber-800 font-medium">
+                <AlertTriangle className="h-4 w-4 shrink-0" />
+                <span>{t('meteoAlert')}</span>
+              </div>
+            )}
           </div>
         )}
 
@@ -171,7 +193,7 @@ export function FlightCard({ flight, locale, showActions = true }: Props) {
             <Button asChild size="sm" variant="outline">
               <Link href={`/${locale}/vols/${flight.id}`}>{tv('detail')}</Link>
             </Button>
-            {flight.statut === 'PLANIFIE' && (
+            {canOrganize && flight.statut === 'PLANIFIE' && (
               <Button asChild size="sm" variant="outline">
                 <Link href={`/${locale}/vols/${flight.id}/organiser`}>{tv('organiser')}</Link>
               </Button>

--- a/components/paiement-form.tsx
+++ b/components/paiement-form.tsx
@@ -14,10 +14,9 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { addPaiement } from '@/lib/actions/paiement'
+import { formLabelClass as labelClassName } from '@/lib/ui'
 
 const MODES = ['ESPECES', 'CHEQUE', 'CB', 'VIREMENT', 'CHEQUE_VACANCES', 'AVOIR'] as const
-
-const labelClassName = 'text-xs font-medium uppercase tracking-wider text-muted-foreground'
 
 type Props = { billetId: string; locale: string }
 

--- a/components/password-strength.tsx
+++ b/components/password-strength.tsx
@@ -1,22 +1,25 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import { useLocale, useTranslations } from 'next-intl'
 import { zxcvbn, zxcvbnOptions } from '@zxcvbn-ts/core'
 import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common'
+import * as zxcvbnEnPackage from '@zxcvbn-ts/language-en'
 import * as zxcvbnFrPackage from '@zxcvbn-ts/language-fr'
 
-let zxcvbnConfigured = false
-function configureZxcvbn() {
-  if (zxcvbnConfigured) return
+let zxcvbnLocale: string | null = null
+function configureZxcvbn(locale: string) {
+  if (zxcvbnLocale === locale) return
+  const pack = locale === 'fr' ? zxcvbnFrPackage : zxcvbnEnPackage
   zxcvbnOptions.setOptions({
-    translations: zxcvbnFrPackage.translations,
+    translations: pack.translations,
     graphs: zxcvbnCommonPackage.adjacencyGraphs,
     dictionary: {
       ...zxcvbnCommonPackage.dictionary,
-      ...zxcvbnFrPackage.dictionary,
+      ...pack.dictionary,
     },
   })
-  zxcvbnConfigured = true
+  zxcvbnLocale = locale
 }
 
 type Props = {
@@ -24,7 +27,7 @@ type Props = {
   minLength?: number
 }
 
-const SCORE_LABELS = ['Tres faible', 'Faible', 'Moyen', 'Bon', 'Excellent'] as const
+const SCORE_KEYS = ['veryWeak', 'weak', 'fair', 'good', 'strong'] as const
 const SCORE_COLORS = [
   'bg-destructive',
   'bg-destructive/60',
@@ -34,12 +37,14 @@ const SCORE_COLORS = [
 ] as const
 
 export function PasswordStrength({ password, minLength = 12 }: Props) {
+  const locale = useLocale()
+  const t = useTranslations('signin.passwordStrength')
   const [isReady, setIsReady] = useState(false)
 
   useEffect(() => {
-    configureZxcvbn()
+    configureZxcvbn(locale)
     setIsReady(true)
-  }, [])
+  }, [locale])
 
   const result = useMemo(() => {
     if (!isReady || !password) return null
@@ -76,7 +81,7 @@ export function PasswordStrength({ password, minLength = 12 }: Props) {
                   : 'text-destructive'
           }
         >
-          {tooShort ? `Minimum ${minLength} caracteres` : SCORE_LABELS[score]}
+          {tooShort ? t('tooShort', { min: minLength }) : t(SCORE_KEYS[score])}
         </span>
         {feedback && !tooShort && (
           <span className="text-muted-foreground truncate max-w-[60%]" title={feedback}>

--- a/lib/ui.ts
+++ b/lib/ui.ts
@@ -1,0 +1,2 @@
+export const formLabelClass =
+  'text-xs font-medium uppercase tracking-wider text-muted-foreground'

--- a/messages/en.json
+++ b/messages/en.json
@@ -58,7 +58,7 @@
     "backToSignin": "Back to sign in",
     "resetPasswordTitle": "New password",
     "newPasswordLabel": "New password",
-    "newPasswordPlaceholder": "Minimum 8 characters",
+    "newPasswordPlaceholder": "Minimum 12 characters",
     "confirmPasswordLabel": "Confirm password",
     "confirmPasswordPlaceholder": "Re-enter password",
     "resetPasswordButton": "Reset password",
@@ -69,7 +69,16 @@
     "invitationSuccess": "Your account is ready. You can now sign in.",
     "orContinueWith": "Or continue with",
     "continueWithGoogle": "Continue with Google",
-    "googleError": "Google sign-in error"
+    "googleError": "Google sign-in error",
+    "loginError": "Sign-in failed",
+    "passwordStrength": {
+      "tooShort": "Minimum {min} characters",
+      "veryWeak": "Very weak",
+      "weak": "Weak",
+      "fair": "Fair",
+      "good": "Good",
+      "strong": "Strong"
+    }
   },
   "admin": {
     "title": "Calpax — Administration",

--- a/messages/en.json
+++ b/messages/en.json
@@ -71,6 +71,8 @@
     "continueWithGoogle": "Continue with Google",
     "googleError": "Google sign-in error",
     "loginError": "Sign-in failed",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
     "passwordStrength": {
       "tooShort": "Minimum {min} characters",
       "veryWeak": "Very weak",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -58,7 +58,7 @@
     "backToSignin": "Retour a la connexion",
     "resetPasswordTitle": "Nouveau mot de passe",
     "newPasswordLabel": "Nouveau mot de passe",
-    "newPasswordPlaceholder": "Minimum 8 caracteres",
+    "newPasswordPlaceholder": "Minimum 12 caractères",
     "confirmPasswordLabel": "Confirmer le mot de passe",
     "confirmPasswordPlaceholder": "Retapez le mot de passe",
     "resetPasswordButton": "Reinitialiser le mot de passe",
@@ -69,7 +69,16 @@
     "invitationSuccess": "Votre compte est pret. Vous pouvez maintenant vous connecter.",
     "orContinueWith": "Ou continuer avec",
     "continueWithGoogle": "Continuer avec Google",
-    "googleError": "Erreur de connexion avec Google"
+    "googleError": "Erreur de connexion avec Google",
+    "loginError": "Erreur de connexion",
+    "passwordStrength": {
+      "tooShort": "Minimum {min} caractères",
+      "veryWeak": "Très faible",
+      "weak": "Faible",
+      "fair": "Moyen",
+      "good": "Bon",
+      "strong": "Excellent"
+    }
   },
   "admin": {
     "title": "Calpax — Administration",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -71,6 +71,8 @@
     "continueWithGoogle": "Continuer avec Google",
     "googleError": "Erreur de connexion avec Google",
     "loginError": "Erreur de connexion",
+    "showPassword": "Afficher le mot de passe",
+    "hidePassword": "Masquer le mot de passe",
     "passwordStrength": {
       "tooShort": "Minimum {min} caractères",
       "veryWeak": "Très faible",


### PR DESCRIPTION
## Summary

Four-lot UI/UX pass based on a three-agent audit of login, dashboard jour-J, and cross-app consistency. Each lot is a separate commit for easy review.

### Lot A — `fix(i18n)`: hardcoded FR strings in auth flows
- `signin/page.tsx`: replace hardcoded `"Erreur de connexion"` with `t('loginError')` — English users now see English errors.
- `components/password-strength.tsx`: move score labels + "too short" message into `signin.passwordStrength.*`; load zxcvbn's language pack by locale so feedback suggestions also match the UI language.
- Add `autoFocus` + `autoComplete` (email, current-password, new-password) on auth forms.
- Fix `newPasswordPlaceholder`: said "Minimum 8 characters" but `minLength` is 12.

### Lot D — `refactor(ui)`: shared `formLabelClass` + unify dashboard h1
- New `lib/ui.ts` with `formLabelClass` constant. Replaces 5 local declarations of the same string.
- Dashboard h1: `text-2xl` → `text-3xl` to match every other top-level page.

### Lot B — `feat(auth)`: spinner, password show/hide, dismissible errors, verify rebrand
- `Loader2` spinner replaces `"..."` on all 4 submit buttons.
- Eye/EyeOff toggle on password fields in signin + reset-password.
- Dismissible error banners with X button.
- Inline live mismatch hint in reset-password (no need to submit).
- Reset-password success now also fires a sonner toast.
- `/auth/verify` rebranded to match the signin card design with logo + wordmark.
- New i18n keys: `signin.showPassword` / `signin.hidePassword`.

### Lot C — `feat(dashboard)`: role-based actions, capacity colors, consolidated weather
- Role-based Organiser button: hidden for PILOTE and EQUIPIER (they can't organise).
- Capacity count colored: green with room / amber at 80%+ / red if overbooked.
- Weather alert merged into the weather section as a secondary line on the same amber-tinted panel (was two disconnected bands).
- Wind / Thermometer icons: `h-3.5` → `h-4` to match the system icon scale.

### Skipped deliberately
- Quick-cancel button on FlightCard — interacts with meteo alert confirm flow, separate design decision.
- Mobile action-button stacking — audit flagged it as marginal (<340px).
- Migrating create-page labels (`ballons/new`, `pilotes/new`) to uppercase form labels — unclear if the plain-label style there is intentional; separate visual call.
- Renaming `maxWindKt` → `maxWindKph` — the value is actually km/h (Open-Meteo is requested with `wind_speed_unit=kmh`). UI labels are correct; only the variable name is misleading. Touches tests + many files; not a user-visible bug.

## Test plan
- [ ] Sign-in page: English users see English errors when credentials are wrong
- [ ] Password strength labels switch language with locale
- [ ] Eye/EyeOff toggle reveals/hides password text
- [ ] Submit buttons show a spinner (not "...") during loading
- [ ] Error banner on sign-in is dismissible via X
- [ ] Reset-password inline mismatch hint appears as soon as fields diverge
- [ ] `/auth/verify` shows the Calpax logo + card layout
- [ ] Dashboard: PILOTE role does not see Organiser button
- [ ] Dashboard: a flight at 6/6 pax shows red capacity; 5/6 shows amber
- [ ] Dashboard: when `meteoAlert = true`, the weather section has an amber background + AlertTriangle row
- [ ] `npm run test` / `tsc --noEmit` clean

https://claude.ai/code/session_01QHoimj4Btam93XvGicBeUS