### PR TITLE
issues batch: #2 #3 #5 #8 #13 #20 + signin hero polish

### DIFF
--- a/app/[locale]/(app)/vols/page.tsx
+++ b/app/[locale]/(app)/vols/page.tsx
@@ -10,6 +10,7 @@ import { WeekGrid } from '@/components/week-grid'
 import type { VolSummary } from '@/components/week-grid'
 import { FlightCard } from '@/components/flight-card'
 import type { FlightCardData } from '@/components/flight-card'
+import { EmptyState } from '@/components/empty-state'
 import { buildVolWhereForRole } from '@/lib/vol/role-filter'
 
 type Props = {
@@ -130,16 +131,21 @@ export default async function VolsPage({ params, searchParams }: Props) {
 
         {/* Mobile: stacked flight cards */}
         <div className="md:hidden space-y-3">
-          {volsRaw.map((vol) => (
-            <FlightCard
-              key={vol.id}
-              flight={mapVolToCardData(vol)}
-              locale={locale}
-              userRole={ctx.role}
+          {volsRaw.length === 0 ? (
+            <EmptyState
+              message={t('noVols')}
+              actionLabel={t('createFirst')}
+              actionHref={`/${locale}/vols/create`}
             />
-          ))}
-          {volsRaw.length === 0 && (
-            <p className="text-center text-muted-foreground py-8">{t('noVols')}</p>
+          ) : (
+            volsRaw.map((vol) => (
+              <FlightCard
+                key={vol.id}
+                flight={mapVolToCardData(vol)}
+                locale={locale}
+                userRole={ctx.role}
+              />
+            ))
           )}
         </div>
 

--- a/app/[locale]/admin/audit/audit-client.tsx
+++ b/app/[locale]/admin/audit/audit-client.tsx
@@ -31,6 +31,7 @@ const ACTIONS = [
 type AuditLog = {
   id: bigint
   exploitantId: string | null
+  impersonatedBy: string | null
   entityType: string
   entityId: string
   action: string
@@ -45,7 +46,19 @@ type Exploitant = {
   name: string
 }
 
-export function AdminAuditClient({ exploitants }: { exploitants: Exploitant[] }) {
+type Admin = {
+  id: string
+  name: string
+  email: string
+}
+
+export function AdminAuditClient({
+  exploitants,
+  admins,
+}: {
+  exploitants: Exploitant[]
+  admins: Admin[]
+}) {
   const t = useTranslations('audit')
   const ta = useTranslations('admin.audit')
   const [exploitantId, setExploitantId] = useState('')
@@ -84,6 +97,7 @@ export function AdminAuditClient({ exploitants }: { exploitants: Exploitant[] })
   }
 
   const exploitantMap = new Map(exploitants.map((e) => [e.id, e.name]))
+  const adminMap = new Map(admins.map((a) => [a.id, a.name || a.email]))
 
   return (
     <Card>
@@ -160,6 +174,7 @@ export function AdminAuditClient({ exploitants }: { exploitants: Exploitant[] })
               <TableRow>
                 <TableHead>{t('fields.date')}</TableHead>
                 <TableHead>{ta('exploitant')}</TableHead>
+                <TableHead>{ta('impersonatedBy')}</TableHead>
                 <TableHead>{t('fields.entity')}</TableHead>
                 <TableHead>{t('fields.action')}</TableHead>
                 <TableHead>{t('fields.field')}</TableHead>
@@ -173,6 +188,15 @@ export function AdminAuditClient({ exploitants }: { exploitants: Exploitant[] })
                   <TableCell className="text-xs">{formatDate(log.createdAt)}</TableCell>
                   <TableCell className="text-xs">
                     {log.exploitantId ? (exploitantMap.get(log.exploitantId) ?? '--') : '--'}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {log.impersonatedBy ? (
+                      <Badge variant="outline" className="border-amber-500 text-amber-700">
+                        {adminMap.get(log.impersonatedBy) ?? log.impersonatedBy.slice(0, 8)}
+                      </Badge>
+                    ) : (
+                      '--'
+                    )}
                   </TableCell>
                   <TableCell>
                     <Badge variant="outline">{log.entityType}</Badge>{' '}

--- a/app/[locale]/admin/audit/page.tsx
+++ b/app/[locale]/admin/audit/page.tsx
@@ -5,15 +5,21 @@ import { AdminAuditClient } from './audit-client'
 export default async function AdminAuditPage() {
   const t = await getTranslations('admin.audit')
 
-  const exploitants = await basePrisma.exploitant.findMany({
-    select: { id: true, name: true },
-    orderBy: { name: 'asc' },
-  })
+  const [exploitants, admins] = await Promise.all([
+    basePrisma.exploitant.findMany({
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    }),
+    basePrisma.user.findMany({
+      where: { role: 'ADMIN_CALPAX' },
+      select: { id: true, name: true, email: true },
+    }),
+  ])
 
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold tracking-tight">{t('title')}</h1>
-      <AdminAuditClient exploitants={exploitants} />
+      <AdminAuditClient exploitants={exploitants} admins={admins} />
     </div>
   )
 }

--- a/app/[locale]/auth/signin/page.tsx
+++ b/app/[locale]/auth/signin/page.tsx
@@ -74,44 +74,108 @@ export default function SignInPage() {
       <div className="w-full max-w-5xl rounded-2xl shadow-xl bg-white flex flex-row overflow-hidden">
         {/* Left panel - branding */}
         <div
-          className="hidden md:flex md:w-1/2 relative flex-col justify-end p-10"
+          className="hidden md:flex md:w-1/2 relative flex-col justify-end p-10 overflow-hidden"
           style={{
             background:
-              'linear-gradient(160deg, #0D3B66 0%, #1A5A96 30%, #3B82F6 55%, #7DD3FC 70%, #F59E0B 88%, #FCD34D 100%)',
+              'linear-gradient(160deg, #0D3B66 0%, #144B82 35%, #1E6BA8 62%, #F59E0B 92%, #FCD34D 100%)',
           }}
         >
-          {/* Diagonal stripe pattern overlay */}
+          {/* Soft radial glow */}
           <div
-            className="absolute inset-0"
+            className="absolute inset-0 pointer-events-none"
             style={{
-              backgroundImage:
-                'repeating-linear-gradient(135deg, transparent, transparent 10px, rgba(255,255,255,0.05) 10px, rgba(255,255,255,0.05) 12px)',
+              background:
+                'radial-gradient(circle at 70% 85%, rgba(252,211,77,0.35), transparent 55%)',
             }}
           />
 
-          {/* Balloon silhouettes */}
-          <div className="absolute inset-0 flex items-start justify-center pt-16">
+          {/* Main balloon — paneled, detailed */}
+          <div className="absolute inset-0 flex items-start justify-center pt-10">
             <svg
-              viewBox="0 0 400 320"
-              className="w-72 h-auto"
+              viewBox="0 0 320 420"
+              className="w-80 h-auto"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
-              style={{ opacity: 0.15 }}
+              style={{ opacity: 0.22 }}
+              aria-hidden="true"
             >
-              {/* Large balloon center */}
-              <ellipse cx="200" cy="100" rx="70" ry="90" fill="white" />
-              <rect x="192" y="185" width="16" height="20" rx="2" fill="white" />
-              <rect x="185" y="205" width="30" height="22" rx="4" fill="white" />
+              {/* Envelope — alternating panels */}
+              <path
+                d="M160 20 C90 20 45 90 45 160 C45 220 85 270 130 290 L190 290 C235 270 275 220 275 160 C275 90 230 20 160 20 Z"
+                fill="white"
+                fillOpacity="0.9"
+              />
+              <path
+                d="M160 20 C130 20 110 90 110 160 C110 220 125 270 145 290 L175 290 C195 270 210 220 210 160 C210 90 190 20 160 20 Z"
+                fill="white"
+                fillOpacity="0.55"
+              />
+              <path d="M160 20 L160 290" stroke="white" strokeOpacity="0.4" strokeWidth="1.5" />
+              <path d="M110 160 L210 160" stroke="white" strokeOpacity="0.4" strokeWidth="1" />
+              <path d="M75 160 L245 160" stroke="white" strokeOpacity="0.25" strokeWidth="1" />
 
-              {/* Small balloon left */}
-              <ellipse cx="80" cy="130" rx="40" ry="52" fill="white" />
-              <rect x="75" y="178" width="10" height="12" rx="2" fill="white" />
-              <rect x="70" y="190" width="20" height="14" rx="3" fill="white" />
+              {/* Burner + lines */}
+              <rect x="152" y="290" width="16" height="14" rx="2" fill="white" />
+              <line
+                x1="140"
+                y1="304"
+                x2="145"
+                y2="345"
+                stroke="white"
+                strokeOpacity="0.8"
+                strokeWidth="1.2"
+              />
+              <line
+                x1="180"
+                y1="304"
+                x2="175"
+                y2="345"
+                stroke="white"
+                strokeOpacity="0.8"
+                strokeWidth="1.2"
+              />
+              <line
+                x1="160"
+                y1="304"
+                x2="160"
+                y2="345"
+                stroke="white"
+                strokeOpacity="0.8"
+                strokeWidth="1.2"
+              />
 
-              {/* Small balloon right */}
-              <ellipse cx="320" cy="80" rx="35" ry="45" fill="white" />
-              <rect x="315" y="122" width="10" height="10" rx="2" fill="white" />
-              <rect x="310" y="132" width="20" height="13" rx="3" fill="white" />
+              {/* Basket */}
+              <rect
+                x="130"
+                y="345"
+                width="60"
+                height="34"
+                rx="4"
+                fill="white"
+                fillOpacity="0.95"
+              />
+              <path
+                d="M130 355 L190 355"
+                stroke="white"
+                strokeOpacity="0.4"
+                strokeWidth="0.8"
+              />
+            </svg>
+          </div>
+
+          {/* Small balloon accent — top right */}
+          <div className="absolute top-14 right-10 pointer-events-none">
+            <svg
+              viewBox="0 0 80 100"
+              className="w-12 h-auto"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              style={{ opacity: 0.18 }}
+              aria-hidden="true"
+            >
+              <ellipse cx="40" cy="40" rx="30" ry="38" fill="white" />
+              <rect x="35" y="76" width="10" height="8" rx="1" fill="white" />
+              <rect x="30" y="82" width="20" height="13" rx="2" fill="white" />
             </svg>
           </div>
 

--- a/components/alerts-banner.tsx
+++ b/components/alerts-banner.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { AlertTriangle, ChevronRight, X } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { AlertTriangle, ChevronRight } from 'lucide-react'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Badge } from '@/components/ui/badge'
 import type { Alert, AlertSeverity } from '@/lib/regulatory/alerts'
@@ -14,33 +15,23 @@ const SEVERITY_VARIANT: Record<AlertSeverity, 'destructive' | 'critical' | 'warn
     OK: 'outline',
   }
 
-function formatDaysRemaining(daysRemaining: number): string {
-  if (daysRemaining <= 0) return 'Expiré'
-  if (daysRemaining === 1) return '1 jour'
-  return `${daysRemaining} jours`
-}
-
-function summaryLabel(alerts: Alert[]): string {
-  const expired = alerts.filter((a) => a.severity === 'EXPIRED').length
-  const critical = alerts.filter((a) => a.severity === 'CRITICAL').length
-
-  const parts: string[] = []
-  if (expired > 0) parts.push(`${expired} expirée${expired > 1 ? 's' : ''}`)
-  if (critical > 0) parts.push(`${critical} critique${critical > 1 ? 's' : ''}`)
-
-  return `${alerts.length} alerte${alerts.length > 1 ? 's' : ''} réglementaire${alerts.length > 1 ? 's' : ''} (${parts.join(', ')})`
-}
-
 /**
  * Single-line alert summary that opens a Sheet with full details.
  * Only shows EXPIRED and CRITICAL alerts (WARNING is sidebar-only).
  */
 export function AlertsBanner({ alerts }: { alerts: Alert[] }) {
+  const t = useTranslations('alerts')
   const [open, setOpen] = useState(false)
 
   if (alerts.length === 0) return null
 
   const hasExpired = alerts.some((a) => a.severity === 'EXPIRED')
+  const expiredCount = alerts.filter((a) => a.severity === 'EXPIRED').length
+  const criticalCount = alerts.filter((a) => a.severity === 'CRITICAL').length
+  const parts: string[] = []
+  if (expiredCount > 0) parts.push(t('countExpired', { count: expiredCount }))
+  if (criticalCount > 0) parts.push(t('countCritical', { count: criticalCount }))
+  const summary = t('summary', { count: alerts.length, parts: parts.join(', ') })
 
   return (
     <>
@@ -54,7 +45,7 @@ export function AlertsBanner({ alerts }: { alerts: Alert[] }) {
           }`}
         >
           <AlertTriangle className="h-4 w-4 shrink-0" />
-          <span className="flex-1 text-left font-medium">{summaryLabel(alerts)}</span>
+          <span className="flex-1 text-left font-medium">{summary}</span>
           <ChevronRight className="h-4 w-4 shrink-0 opacity-50" />
         </button>
       </div>
@@ -62,7 +53,7 @@ export function AlertsBanner({ alerts }: { alerts: Alert[] }) {
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetContent>
           <SheetHeader>
-            <SheetTitle>Alertes réglementaires</SheetTitle>
+            <SheetTitle>{t('title')}</SheetTitle>
           </SheetHeader>
           <div className="mt-4 flex flex-col gap-3">
             {alerts.map((alert) => (
@@ -73,15 +64,15 @@ export function AlertsBanner({ alerts }: { alerts: Alert[] }) {
                 <div className="flex flex-col gap-1">
                   <span className="text-sm font-medium">{alert.entityName}</span>
                   <span className="text-xs text-muted-foreground">
-                    {alert.alertType === 'CAMO_EXPIRY' ? 'Certificat CAMO' : 'Licence BFCL'}
+                    {alert.alertType === 'CAMO_EXPIRY' ? t('camoExpiry') : t('bfclExpiry')}
                   </span>
                 </div>
                 <div className="flex flex-col items-end gap-1">
                   <Badge variant={SEVERITY_VARIANT[alert.severity]}>
-                    {alert.severity === 'EXPIRED' ? 'Expiré' : 'Critique'}
+                    {alert.severity === 'EXPIRED' ? t('expired') : t('critical')}
                   </Badge>
                   <span className="text-xs text-muted-foreground">
-                    {formatDaysRemaining(alert.daysRemaining)}
+                    {t('daysRemaining', { days: Math.max(0, alert.daysRemaining) })}
                   </span>
                 </div>
               </div>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -70,14 +70,14 @@ export function AppSidebar({ userRole }: { userRole?: string }) {
       items: [{ key: 'home', href: `/${locale}`, icon: Home }],
     },
     {
-      label: 'Activité',
+      label: t('groups.activity'),
       items: [
         { key: 'billets', href: `/${locale}/billets`, icon: Ticket },
         { key: 'vols', href: `/${locale}/vols`, icon: Plane },
       ],
     },
     {
-      label: 'Flotte',
+      label: t('groups.fleet'),
       items: [
         { key: 'ballons', href: `/${locale}/ballons`, icon: Wind },
         { key: 'pilotes', href: `/${locale}/pilotes`, icon: User2 },
@@ -87,7 +87,7 @@ export function AppSidebar({ userRole }: { userRole?: string }) {
       ],
     },
     {
-      label: 'Administration',
+      label: t('groups.administration'),
       items: [
         { key: 'settings', href: `/${locale}/settings`, icon: Settings },
         { key: 'rgpd', href: `/${locale}/rgpd`, icon: Shield },

--- a/components/impersonation-banner.tsx
+++ b/components/impersonation-banner.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import Link from 'next/link'
-import { useLocale } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import { Eye } from 'lucide-react'
 
 type Props = {
   exploitantName: string
@@ -9,17 +10,24 @@ type Props = {
 
 export function ImpersonationBanner({ exploitantName }: Props) {
   const locale = useLocale()
+  const t = useTranslations('impersonation')
 
   return (
-    <div className="bg-amber-500 text-amber-950 px-4 py-2 text-sm font-medium flex items-center justify-between">
-      <span>
-        Vous etes connecte en tant que <strong>{exploitantName}</strong>
-      </span>
+    <div
+      role="alert"
+      className="sticky top-0 z-40 bg-amber-500 text-amber-950 px-4 py-2 text-sm font-medium flex items-center justify-between gap-3 shadow-md"
+    >
+      <div className="flex items-center gap-2">
+        <Eye className="h-4 w-4 shrink-0" />
+        <span>
+          {t('connectedAs')} <strong>{exploitantName}</strong>
+        </span>
+      </div>
       <Link
         href={`/${locale}/admin`}
-        className="rounded-md bg-amber-600 px-3 py-1 text-xs font-bold text-white hover:bg-amber-700 transition-colors"
+        className="rounded-md bg-amber-600 px-3 py-1 text-xs font-bold text-white hover:bg-amber-700 transition-colors whitespace-nowrap"
       >
-        Revenir
+        {t('exit')}
       </Link>
     </div>
   )

--- a/lib/actions/admin.ts
+++ b/lib/actions/admin.ts
@@ -7,7 +7,9 @@ import { basePrisma } from '@/lib/db/base'
 import { revalidatePath } from 'next/cache'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { requireRole } from '@/lib/auth/requireRole'
+import { getContext } from '@/lib/context'
 import { sendInvitationEmail } from '@/lib/email/invitation'
+import { AuditAction } from '@prisma/client'
 
 export async function revokeSession(sessionId: string) {
   return requireAuth(async () => {
@@ -113,6 +115,7 @@ export async function toggleUserBan(args: {
 }): Promise<{ error?: string }> {
   return requireAuth(async () => {
     requireRole('ADMIN_CALPAX')
+    const ctx = getContext()
 
     try {
       if (args.banned) {
@@ -129,6 +132,26 @@ export async function toggleUserBan(args: {
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Opération refusée'
       return { error: msg }
+    }
+
+    // Better Auth's ban/unban bypasses the audit extension since it uses its own
+    // Prisma client; emit an explicit auditLog row so the action is traceable.
+    try {
+      await basePrisma.auditLog.create({
+        data: {
+          exploitantId: null,
+          userId: ctx.userId,
+          impersonatedBy: ctx.impersonatedBy ?? null,
+          entityType: 'User',
+          entityId: args.userId,
+          action: AuditAction.UPDATE,
+          field: 'banned',
+          beforeValue: !args.banned,
+          afterValue: args.banned,
+        },
+      })
+    } catch (err) {
+      console.warn('toggleUserBan: failed to write audit row', err)
     }
 
     revalidatePath('/admin/users')

--- a/lib/actions/rgpd.ts
+++ b/lib/actions/rgpd.ts
@@ -2,9 +2,7 @@
 
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { requireRole } from '@/lib/auth/requireRole'
-import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
-import { basePrisma } from '@/lib/db/base'
 import { decrypt } from '@/lib/crypto'
 
 export type PassagerSearchResult = {
@@ -21,26 +19,26 @@ export async function searchPassagers(query: string): Promise<PassagerSearchResu
   return requireAuth(async () => {
     if (!query || query.length < 2) return []
 
-    const ctx = getContext()
-    const pattern = `%${query}%`
-    const passagers = await basePrisma.$queryRaw<
-      {
-        id: string
-        prenom: string
-        nom: string
-        email: string | null
-        telephone: string | null
-        billetId: string
-        billetReference: string
-      }[]
-    >`
-      SELECT p.id, p.prenom, p.nom, p.email, p.telephone, p."billetId", b.reference AS "billetReference"
-      FROM passager p
-      JOIN billet b ON b.id = p."billetId"
-      WHERE p."exploitantId" = ${ctx.exploitantId}
-        AND (p.nom ILIKE ${pattern} OR p.prenom ILIKE ${pattern} OR p.email ILIKE ${pattern} OR p.telephone LIKE ${pattern})
-      LIMIT 50
-    `
+    const passagers = await db.passager.findMany({
+      where: {
+        OR: [
+          { nom: { contains: query, mode: 'insensitive' } },
+          { prenom: { contains: query, mode: 'insensitive' } },
+          { email: { contains: query, mode: 'insensitive' } },
+          { telephone: { contains: query } },
+        ],
+      },
+      select: {
+        id: true,
+        prenom: true,
+        nom: true,
+        email: true,
+        telephone: true,
+        billetId: true,
+        billet: { select: { reference: true } },
+      },
+      take: 50,
+    })
 
     return passagers.map((p) => ({
       id: p.id,
@@ -48,7 +46,7 @@ export async function searchPassagers(query: string): Promise<PassagerSearchResu
       nom: p.nom,
       email: p.email,
       telephone: p.telephone,
-      billetReference: p.billetReference,
+      billetReference: p.billet.reference,
       billetId: p.billetId,
     }))
   }) as Promise<PassagerSearchResult[]>

--- a/messages/en.json
+++ b/messages/en.json
@@ -146,6 +146,7 @@
     "audit": {
       "title": "Audit (all tenants)",
       "exploitant": "Operator",
+      "impersonatedBy": "Impersonated by",
       "all": "All",
       "noEntries": "No changes"
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -178,7 +178,23 @@
     "audit": "Audit",
     "profil": "My profile",
     "signout": "Sign out",
-    "superAdmin": "Super Admin"
+    "superAdmin": "Super Admin",
+    "groups": {
+      "activity": "Activity",
+      "fleet": "Fleet",
+      "administration": "Administration"
+    }
+  },
+  "alerts": {
+    "title": "Regulatory alerts",
+    "expired": "Expired",
+    "critical": "Critical",
+    "daysRemaining": "{days, plural, =0 {Expired} one {# day} other {# days}}",
+    "summary": "{count, plural, one {# regulatory alert} other {# regulatory alerts}} ({parts})",
+    "countExpired": "{count, plural, one {# expired} other {# expired}}",
+    "countCritical": "{count, plural, one {# critical} other {# critical}}",
+    "camoExpiry": "CAMO certificate",
+    "bfclExpiry": "BFCL licence"
   },
   "settings": {
     "title": "Operator Settings",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,8 @@
 {
+  "impersonation": {
+    "connectedAs": "Viewing as",
+    "exit": "Exit"
+  },
   "common": {
     "forbidden": "Access denied",
     "forbiddenMessage": "You do not have permission to access this page. Contact your administrator if you believe this is an error.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,4 +1,8 @@
 {
+  "impersonation": {
+    "connectedAs": "Connecté en tant que",
+    "exit": "Revenir"
+  },
   "common": {
     "forbidden": "Accès refusé",
     "forbiddenMessage": "Vous n'avez pas les droits nécessaires pour accéder à cette page. Contactez votre administrateur si vous pensez qu'il s'agit d'une erreur.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -146,6 +146,7 @@
     "audit": {
       "title": "Audit (toutes tenants)",
       "exploitant": "Exploitant",
+      "impersonatedBy": "Impersonné par",
       "all": "Tous",
       "noEntries": "Aucune modification"
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -178,7 +178,23 @@
     "audit": "Audit",
     "profil": "Mon profil",
     "signout": "Déconnexion",
-    "superAdmin": "Super Admin"
+    "superAdmin": "Super Admin",
+    "groups": {
+      "activity": "Activité",
+      "fleet": "Flotte",
+      "administration": "Administration"
+    }
+  },
+  "alerts": {
+    "title": "Alertes réglementaires",
+    "expired": "Expiré",
+    "critical": "Critique",
+    "daysRemaining": "{days, plural, =0 {Expiré} one {# jour} other {# jours}}",
+    "summary": "{count, plural, one {# alerte réglementaire} other {# alertes réglementaires}} ({parts})",
+    "countExpired": "{count, plural, one {# expirée} other {# expirées}}",
+    "countCritical": "{count, plural, one {# critique} other {# critiques}}",
+    "camoExpiry": "Certificat CAMO",
+    "bfclExpiry": "Licence BFCL"
   },
   "settings": {
     "title": "Paramètres de l'exploitant",


### PR DESCRIPTION
## Summary

Autonomous batch of GitHub issue fixes. 6 closed, 1 commented (needs product call), + login hero polish.

### Closed
- **#2** `fix(audit)` — `toggleUserBan` now emits an explicit `auditLog.create` after ban/unban, since Better Auth's admin plugin uses its own Prisma client and bypasses the `auditExtension`. Includes `impersonatedBy`. [RGPD art. 30]
- **#3** `refactor(rgpd)` — `searchPassagers` switched from `basePrisma.$queryRaw` with a hand-written `exploitantId` filter to `db.passager.findMany({ OR: [...] })` so the tenant extension enforces isolation automatically.
- **#5** `fix(ui)` — vols mobile view showed a bare "Aucun vol" paragraph; replaced with `<EmptyState>` + CTA. All other list pages were already correct.
- **#13** `fix(i18n)` — sidebar group labels (`Activité` / `Flotte` / `Administration`) moved to `nav.groups.*`; alerts-banner strings moved to `alerts.*` with ICU plurals (`alerts.summary`, `alerts.daysRemaining`, etc.) via next-intl.
- **#20** `feat(admin)` — added "Impersonné par" column in `/admin/audit` with amber-bordered badge showing the admin who performed the action while impersonating. Resolves admin user ids to names server-side.

### Partial
- **#8** — banner component polished (`sticky top-0 z-40`, shadow, Eye icon, `role="alert"`, i18n). **Full wiring of session-level impersonation is out of scope** — the banner is never rendered anywhere today because `?impersonate=X` from `/admin` isn't consumed. Left a detailed comment on the issue.
- **#6** — commented. The billet form is not actually multi-step (4 Card sections on a single long page). Proposed three concrete options (section navigator / sticky ToC / real wizard) but the choice is a product decision.

### Bonus
- `feat(auth)` — signin hero redesign (option B from earlier chat): single paneled balloon with burner + basket, small second balloon for depth, softer gradient, dropped the diagonal stripe pattern. Pure SVG, no new assets.

### Skipped for this batch (large / needs decisions)
- #4 encrypt Passager email + telephone (schema + data migration)
- #7 persistent expiration top-bar (design)
- #11 Paiement Decimal (explicitly "keep for now")
- #12 Meteo-France AROME HD (research task)
- #14 RGPD 5-year retention cron
- #15/16 2FA / Passkeys (V2)
- #17 session management UI (medium design)
- #18 Remember me (Better Auth config)
- #19 E2E RBAC tests (infrastructure)
- #9 react-pdf SectionTitle constraint (minor design note)

## Test plan
- [ ] Ban/unban a user → check `/admin/audit` for a row with `entityType=User`, `field=banned`
- [ ] RGPD search finds passagers only from current tenant (unchanged behavior)
- [ ] Vols mobile view with 0 vols shows the EmptyState + "Planifier un vol" CTA
- [ ] Sidebar group labels render in FR and EN
- [ ] Alerts banner pluralizes correctly (1 alerte vs 2 alertes, fr + en)
- [ ] Admin audit table shows "Impersonné par" column with badge when impersonatedBy set
- [ ] Signin page renders new paneled balloon hero

https://claude.ai/code/session_01QHoimj4Btam93XvGicBeUS