### PR TITLE
auth batch: #9 + #17 + #18 (remember me, sessions UI, PDF doc)

### DIFF
--- a/app/[locale]/(app)/profil/page.tsx
+++ b/app/[locale]/(app)/profil/page.tsx
@@ -7,13 +7,15 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { ChangePasswordForm } from '@/components/change-password-form'
 import { LinkedAccounts } from '@/components/linked-accounts'
+import { MySessionsCard } from '@/components/my-sessions-card'
+import { getMySessions } from '@/lib/actions/session'
 
 export default async function ProfilPage() {
   return requireAuth(async () => {
     const t = await getTranslations('profil')
     const ctx = getContext()
 
-    const [user, exploitant, accounts] = await Promise.all([
+    const [user, exploitant, accounts, sessions] = await Promise.all([
       db.user.findUniqueOrThrow({
         where: { id: ctx.userId },
       }),
@@ -26,6 +28,7 @@ export default async function ProfilPage() {
         where: { userId: ctx.userId },
         select: { providerId: true },
       }),
+      getMySessions(),
     ])
 
     const linkedProviders = accounts.map((a) => a.providerId).filter((p) => p !== 'credential')
@@ -90,6 +93,8 @@ export default async function ProfilPage() {
         <LinkedAccounts linkedProviders={linkedProviders} hasCredential={hasCredential} />
 
         <ChangePasswordForm />
+
+        <MySessionsCard sessions={sessions} />
       </div>
     )
   })

--- a/app/[locale]/auth/signin/page.tsx
+++ b/app/[locale]/auth/signin/page.tsx
@@ -14,6 +14,7 @@ export default function SignInPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
+  const [rememberMe, setRememberMe] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [mode, setMode] = useState<Mode>('signin')
@@ -24,7 +25,7 @@ export default function SignInPage() {
     setLoading(true)
     setError(null)
     try {
-      const result = await signIn.email({ email, password })
+      const result = await signIn.email({ email, password, rememberMe })
       if (result.error) {
         setError(result.error.message ?? t('loginError'))
       } else {
@@ -290,7 +291,16 @@ export default function SignInPage() {
                     </button>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="flex items-center justify-between">
+                  <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={rememberMe}
+                      onChange={(e) => setRememberMe(e.target.checked)}
+                      className="h-3.5 w-3.5 rounded border-border accent-primary"
+                    />
+                    {t('rememberMe')}
+                  </label>
                   <button
                     type="button"
                     onClick={() => {

--- a/components/my-sessions-card.tsx
+++ b/components/my-sessions-card.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useTranslations } from 'next-intl'
+import { toast } from 'sonner'
+import { Loader2, Monitor, Smartphone } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { revokeMySession, type MySession } from '@/lib/actions/session'
+
+type Props = {
+  sessions: MySession[]
+}
+
+function deviceLabel(ua: string | null): { label: string; icon: typeof Monitor } {
+  if (!ua) return { label: 'Inconnu', icon: Monitor }
+  const isMobile = /Mobi|Android|iPhone|iPad/i.test(ua)
+  const browser =
+    (ua.match(/Chrome\/[\d.]+/)?.[0] && 'Chrome') ||
+    (ua.match(/Firefox\/[\d.]+/)?.[0] && 'Firefox') ||
+    (ua.match(/Safari\/[\d.]+/)?.[0] && 'Safari') ||
+    (ua.match(/Edg\/[\d.]+/)?.[0] && 'Edge') ||
+    'Navigateur'
+  const os =
+    (ua.includes('Windows') && 'Windows') ||
+    (ua.includes('Macintosh') && 'macOS') ||
+    (ua.includes('Linux') && 'Linux') ||
+    (ua.includes('Android') && 'Android') ||
+    (ua.includes('iPhone') && 'iOS') ||
+    ''
+  return { label: [browser, os].filter(Boolean).join(' — '), icon: isMobile ? Smartphone : Monitor }
+}
+
+export function MySessionsCard({ sessions }: Props) {
+  const t = useTranslations('profil.sessions')
+  const [pending, startTransition] = useTransition()
+  const [revokingId, setRevokingId] = useState<string | null>(null)
+  const [revoked, setRevoked] = useState<Set<string>>(new Set())
+
+  function handleRevoke(sessionId: string) {
+    if (!window.confirm(t('revokeConfirm'))) return
+    setRevokingId(sessionId)
+    startTransition(async () => {
+      const result = await revokeMySession(sessionId)
+      setRevokingId(null)
+      if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.success(t('revokeSuccess'))
+        setRevoked((prev) => new Set(prev).add(sessionId))
+      }
+    })
+  }
+
+  function formatDate(date: Date) {
+    return new Date(date).toLocaleString('fr-FR', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    })
+  }
+
+  const visible = sessions.filter((s) => !revoked.has(s.id))
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t('title')}</CardTitle>
+        <p className="text-xs text-muted-foreground">{t('description')}</p>
+      </CardHeader>
+      <CardContent>
+        {visible.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('empty')}</p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {visible.map((s) => {
+              const { label, icon: Icon } = deviceLabel(s.userAgent)
+              const isRevoking = pending && revokingId === s.id
+              return (
+                <li key={s.id} className="flex items-center gap-3 py-3">
+                  <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium truncate">{label}</span>
+                      {s.isCurrent && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          {t('currentSession')}
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {s.ipAddress ?? '—'} · {formatDate(s.createdAt)}
+                    </p>
+                  </div>
+                  {!s.isCurrent && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={isRevoking}
+                      onClick={() => handleRevoke(s.id)}
+                    >
+                      {isRevoking && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
+                      {t('revoke')}
+                    </Button>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -1,0 +1,55 @@
+'use server'
+
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { basePrisma } from '@/lib/db/base'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getContext } from '@/lib/context'
+import { revalidatePath } from 'next/cache'
+
+export type MySession = {
+  id: string
+  ipAddress: string | null
+  userAgent: string | null
+  createdAt: Date
+  expiresAt: Date
+  isCurrent: boolean
+}
+
+export async function getMySessions(): Promise<MySession[]> {
+  return requireAuth(async () => {
+    const ctx = getContext()
+    const currentSession = await auth.api.getSession({ headers: await headers() })
+    const currentId = currentSession?.session?.id ?? null
+
+    const sessions = await basePrisma.session.findMany({
+      where: { userId: ctx.userId, expiresAt: { gt: new Date() } },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        ipAddress: true,
+        userAgent: true,
+        createdAt: true,
+        expiresAt: true,
+      },
+    })
+
+    return sessions.map((s) => ({ ...s, isCurrent: s.id === currentId }))
+  }) as Promise<MySession[]>
+}
+
+export async function revokeMySession(sessionId: string): Promise<{ error?: string }> {
+  return requireAuth(async () => {
+    const ctx = getContext()
+    // Scope the delete to ctx.userId so a user can never revoke another user's
+    // session by guessing an id.
+    const result = await basePrisma.session.deleteMany({
+      where: { id: sessionId, userId: ctx.userId },
+    })
+    if (result.count === 0) {
+      return { error: 'Session introuvable' }
+    }
+    revalidatePath('/profil')
+    return {}
+  })
+}

--- a/lib/pdf/fiche-vol.tsx
+++ b/lib/pdf/fiche-vol.tsx
@@ -349,6 +349,11 @@ function PageFooter({ exploitant }: { exploitant: FicheVolData['exploitant'] }) 
   )
 }
 
+// `children` is typed `string` (not ReactNode) because @react-pdf/renderer's
+// <Text> renders glyphs per node: passing multiple children (e.g. `<>{a}{b}</>`
+// or raw concatenations inside JSX) crashes at render with an obscure "Cannot
+// add a child that doesn't have a YogaNode" error. Use a template literal at
+// the call site (e.g. `{`PASSAGERS (${n})`}`) when the title is dynamic.
 function SectionTitle({ children }: { children: string }) {
   return <Text style={styles.sectionTitle}>{children}</Text>
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -54,6 +54,7 @@
     "connectTitle": "Sign in to your account",
     "appDescription": "Hot air balloon flight management SaaS",
     "footer": "Calpax 2026",
+    "rememberMe": "Remember me",
     "forgotPassword": "Forgot password?",
     "forgotPasswordTitle": "Reset your password",
     "sendResetLink": "Send reset link",

--- a/messages/en.json
+++ b/messages/en.json
@@ -717,6 +717,15 @@
     "passwordMismatch": "Passwords do not match",
     "passwordChanged": "Password updated",
     "passwordError": "Error changing password",
+    "sessions": {
+      "title": "Active sessions",
+      "description": "Devices currently signed in to your account. You can revoke a session to sign out that device.",
+      "currentSession": "Current session",
+      "revoke": "Sign out",
+      "revokeConfirm": "Sign out this device? The session will be revoked immediately.",
+      "revokeSuccess": "Session revoked",
+      "empty": "No active sessions."
+    },
     "linkedAccounts": {
       "title": "Sign-in methods",
       "description": "Link one or more accounts to sign in faster. You can remove them at any time.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -54,6 +54,7 @@
     "connectTitle": "Connectez-vous à votre compte",
     "appDescription": "SaaS de gestion de vols en montgolfière",
     "footer": "Calpax 2026",
+    "rememberMe": "Se souvenir de moi",
     "forgotPassword": "Mot de passe oublie ?",
     "forgotPasswordTitle": "Reinitialiser votre mot de passe",
     "sendResetLink": "Envoyer un lien de reinitialisation",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -717,6 +717,15 @@
     "passwordMismatch": "Les mots de passe ne correspondent pas",
     "passwordChanged": "Mot de passe mis a jour",
     "passwordError": "Erreur lors du changement de mot de passe",
+    "sessions": {
+      "title": "Sessions actives",
+      "description": "Les appareils actuellement connectés à votre compte. Vous pouvez révoquer une session pour déconnecter l'appareil.",
+      "currentSession": "Session actuelle",
+      "revoke": "Déconnecter",
+      "revokeConfirm": "Déconnecter cet appareil ? La session sera immédiatement révoquée.",
+      "revokeSuccess": "Session révoquée",
+      "empty": "Aucune session active."
+    },
     "linkedAccounts": {
       "title": "Methodes de connexion",
       "description": "Liez un ou plusieurs comptes pour vous connecter plus rapidement. Vous pouvez les retirer a tout moment.",


### PR DESCRIPTION
## Summary

Auth/session batch — 3 issues closed, 1 deferred with scope reassessment.

### Closed
- **#9** `docs(pdf)` — `SectionTitle` in `lib/pdf/fiche-vol.tsx` typed its children as `string` (not ReactNode) because `@react-pdf/renderer` crashes on multi-child `<Text>` with an opaque "YogaNode" error. Added a comment explaining WHY so a future contributor doesn't widen the type to silence TS and silently break PDF generation.
- **#18** `feat(auth)` — "Remember me" checkbox on signin (default checked). Passes `rememberMe` to Better Auth's `signIn.email()`. Checked → persistent cookie for `session.expiresIn` (7 days); unchecked → session cookie (removed on browser close). i18n under `signin.rememberMe`.
- **#17** `feat(profil)` — Active sessions management in `/profil`. New `lib/actions/session.ts` with `getMySessions()` + `revokeMySession(id)`, both scoped to `ctx.userId` so a user can never revoke another user's session. New `MySessionsCard` component with device icon (Monitor/Smartphone by UA), parsed "Chrome — macOS" label, IP + start date. Current session is badged and has no revoke button (can't lock yourself out of the page you're on). i18n under `profil.sessions.*`.

### Deferred — scope reassessment
- **#15** (2FA/TOTP for ADMIN_CALPAX) — commented on the issue. Initially triaged as "medium but mechanical", but on closer look it's ~4h: schema migration (can't do without DB locally), signin flow 2FA challenge (second screen, backup codes), profil setup UI (QR code + verification + disable flow with password confirm), admin enforcement middleware. Recommended keeping the issue open until a dedicated session; the issue tag says `Before ouverture multi-exploitant` so no rush.

## Test plan
- [ ] Sign in with "Remember me" unchecked → close browser → reopen → should be signed out
- [ ] Sign in with "Remember me" checked → cookie persists 7 days
- [ ] `/profil` → "Sessions actives" card lists current session (badged), no revoke button on current
- [ ] Open a second browser, sign in, then revoke it from the first → second browser loses session
- [ ] `npm run test` / `tsc --noEmit` clean

https://claude.ai/code/session_01QHoimj4Btam93XvGicBeUS