### PR TITLE
refonte(phase 1): Crepuscule tokens + cockpit shell

### DIFF
--- a/app/[locale]/(app)/layout.tsx
+++ b/app/[locale]/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import { SidebarProvider, SidebarInset, SidebarTrigger } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
 import { AlertsBanner } from '@/components/alerts-banner'
+import { CalpaxWordmark } from '@/components/brand/calpax-wordmark'
 import { runWithContext } from '@/lib/context'
 import { db } from '@/lib/db'
 import { buildBallonAlerts, buildPiloteAlerts, sortAlerts } from '@/lib/regulatory/alerts'
@@ -26,8 +27,7 @@ export default async function AppLayout({ children, params }: Props) {
   const exploitantId = user.exploitantId as string
   const role = (user.role as string as UserRole) ?? 'GERANT'
 
-  // Fetch alert count for sidebar badge
-  const alerts = await runWithContext(
+  const { alerts, exploitantName, pendingTicketsCount } = await runWithContext(
     {
       userId: session.user.id,
       exploitantId,
@@ -35,7 +35,7 @@ export default async function AppLayout({ children, params }: Props) {
     },
     async () => {
       const today = new Date()
-      const [ballons, pilotes] = await Promise.all([
+      const [ballons, pilotes, exploitant, ticketsCount] = await Promise.all([
         db.ballon.findMany({
           where: { actif: true },
           select: { id: true, nom: true, immatriculation: true, camoExpiryDate: true, actif: true },
@@ -44,11 +44,18 @@ export default async function AppLayout({ children, params }: Props) {
           where: { actif: true },
           select: { id: true, prenom: true, nom: true, dateExpirationLicence: true, actif: true },
         }),
+        db.exploitant.findFirst({ select: { name: true } }),
+        db.billet.count({ where: { statut: 'EN_ATTENTE' } }).catch(() => 0),
       ])
-      return sortAlerts([
+      const sorted = sortAlerts([
         ...buildBallonAlerts(ballons, today),
         ...buildPiloteAlerts(pilotes, today),
       ])
+      return {
+        alerts: sorted,
+        exploitantName: exploitant?.name ?? null,
+        pendingTicketsCount: ticketsCount,
+      }
     },
   )
 
@@ -56,11 +63,15 @@ export default async function AppLayout({ children, params }: Props) {
 
   return (
     <SidebarProvider>
-      <AppSidebar userRole={role} />
+      <AppSidebar
+        userRole={role}
+        exploitantName={exploitantName}
+        pendingTicketsCount={pendingTicketsCount}
+      />
       <SidebarInset>
-        <header className="sticky top-0 z-10 flex h-12 items-center gap-2 border-b bg-background px-4 md:hidden">
+        <header className="sticky top-0 z-10 flex h-12 items-center gap-2 border-b border-sky-100 bg-card px-4 md:hidden">
           <SidebarTrigger />
-          <span className="text-sm font-semibold text-primary">Calpax</span>
+          <CalpaxWordmark size={14} />
         </header>
         <AlertsBanner alerts={criticalAlerts} />
         <main className="flex-1 p-6">{children}</main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,9 +4,14 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Register Crepuscule palette + fonts as Tailwind tokens */
 @theme inline {
-    --font-heading: var(--font-sans);
+    --font-heading: var(--font-display);
     --font-sans: var(--font-sans);
+    --font-mono: var(--font-mono);
+    --font-display: var(--font-display);
+
+    /* shadcn semantic */
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-muted-foreground: var(--sidebar-muted-foreground);
     --color-sidebar-border: var(--sidebar-border);
@@ -46,6 +51,37 @@
     --color-warning-foreground: var(--warning-foreground);
     --color-info: var(--info);
     --color-info-foreground: var(--info-foreground);
+
+    /* Crepuscule palette — sky (neutres bleu-nuit) */
+    --color-sky-0: var(--sky-0);
+    --color-sky-50: var(--sky-50);
+    --color-sky-100: var(--sky-100);
+    --color-sky-200: var(--sky-200);
+    --color-sky-300: var(--sky-300);
+    --color-sky-400: var(--sky-400);
+    --color-sky-500: var(--sky-500);
+    --color-sky-600: var(--sky-600);
+    --color-sky-700: var(--sky-700);
+    --color-sky-800: var(--sky-800);
+    --color-sky-900: var(--sky-900);
+    --color-sky-950: var(--sky-950);
+
+    /* Ink (bleu marine primary) */
+    --color-ink-500: var(--ink-500);
+    --color-ink-600: var(--ink-600);
+    --color-ink-700: var(--ink-700);
+    --color-ink-800: var(--ink-800);
+
+    /* Dusk (accent couchant) */
+    --color-dusk-50: var(--dusk-50);
+    --color-dusk-100: var(--dusk-100);
+    --color-dusk-200: var(--dusk-200);
+    --color-dusk-300: var(--dusk-300);
+    --color-dusk-400: var(--dusk-400);
+    --color-dusk-500: var(--dusk-500);
+    --color-dusk-600: var(--dusk-600);
+    --color-dusk-700: var(--dusk-700);
+
     --radius-sm: calc(var(--radius) * 0.6);
     --radius-md: calc(var(--radius) * 0.8);
     --radius-lg: var(--radius);
@@ -56,101 +92,152 @@
 }
 
 :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.208 0.042 265.75);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.208 0.042 265.75);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.208 0.042 265.75);
-    --primary: oklch(0.382 0.1 248.68);
-    --primary-foreground: oklch(1 0 0);
-    --secondary: oklch(0.968 0.007 247.86);
-    --secondary-foreground: oklch(0.208 0.042 265.75);
-    --muted: oklch(0.968 0.007 247.86);
-    --muted-foreground: oklch(0.554 0.022 257.42);
-    --accent: oklch(0.968 0.007 247.86);
-    --accent-foreground: oklch(0.382 0.1 248.68);
-    --destructive: oklch(0.444 0.177 26.9);
-    --destructive-foreground: oklch(1 0 0);
-    --success: oklch(0.527 0.154 155.99);
-    --success-foreground: oklch(1 0 0);
-    --warning: oklch(0.681 0.162 75.83);
-    --warning-foreground: oklch(0.244 0.065 57.59);
-    --info: oklch(0.554 0.195 255.13);
-    --info-foreground: oklch(1 0 0);
-    --border: oklch(0.929 0.011 252.84);
-    --input: oklch(0.929 0.011 252.84);
-    --ring: oklch(0.382 0.1 248.68);
+    /* Crepuscule palette (hex) */
+    --sky-0: #fafbfc;
+    --sky-50: #f2f5f8;
+    --sky-100: #e7ecf2;
+    --sky-200: #ced7e1;
+    --sky-300: #a8b5c4;
+    --sky-400: #7889a0;
+    --sky-500: #506079;
+    --sky-600: #364459;
+    --sky-700: #1f2d44;
+    --sky-800: #131e32;
+    --sky-900: #0a1424;
+    --sky-950: #05101f;
+
+    --ink-500: #1b3a5e;
+    --ink-600: #13304e;
+    --ink-700: #0e2540;
+    --ink-800: #091a30;
+
+    --dusk-50: #fef3e8;
+    --dusk-100: #fde0c1;
+    --dusk-200: #fcc387;
+    --dusk-300: #f89f4b;
+    --dusk-400: #ee7f26;
+    --dusk-500: #db6411;
+    --dusk-600: #b84d0c;
+    --dusk-700: #8f3a0c;
+
+    /* shadcn mapping */
+    --background: var(--sky-50);
+    --foreground: var(--sky-900);
+    --card: #ffffff;
+    --card-foreground: var(--sky-900);
+    --popover: #ffffff;
+    --popover-foreground: var(--sky-900);
+    --primary: var(--ink-500);
+    --primary-foreground: #ffffff;
+    --secondary: var(--sky-100);
+    --secondary-foreground: var(--sky-700);
+    --muted: var(--sky-100);
+    --muted-foreground: var(--sky-500);
+    --accent: var(--dusk-50);
+    --accent-foreground: var(--dusk-700);
+    --destructive: #b42525;
+    --destructive-foreground: #ffffff;
+    --success: #2f8a5f;
+    --success-foreground: #ffffff;
+    --warning: #c27a00;
+    --warning-foreground: #ffffff;
+    --info: #2563a8;
+    --info-foreground: #ffffff;
+    --border: var(--sky-100);
+    --input: var(--sky-100);
+    --ring: var(--dusk-500);
     --radius: 0.625rem;
-    --font-heading: var(--font-sans);
-    --sidebar-background: oklch(0.22 0.045 255);
-    --sidebar-foreground: oklch(0.7 0.04 250);
-    --sidebar-primary: oklch(0.82 0.11 85);
-    --sidebar-primary-foreground: oklch(0.22 0.045 255);
-    --sidebar-accent: oklch(0.32 0.05 255);
-    --sidebar-accent-foreground: oklch(0.95 0.01 250);
-    --sidebar-border: oklch(0.32 0.04 255);
-    --sidebar-ring: oklch(0.82 0.11 85);
-    --sidebar-muted-foreground: oklch(0.55 0.04 250);
-    --chart-1: oklch(0.382 0.1 248.68);
-    --chart-2: oklch(0.527 0.154 155.99);
-    --chart-3: oklch(0.681 0.162 75.83);
-    --chart-4: oklch(0.554 0.195 255.13);
-    --chart-5: oklch(0.554 0.022 257.42);
-    --sidebar: hsl(0 0% 98%);
+
+    /* Sidebar — option A: ink-600 dark adouci */
+    --sidebar-background: var(--ink-600);
+    --sidebar-foreground: var(--sky-200);
+    --sidebar-primary: var(--dusk-500);
+    --sidebar-primary-foreground: #ffffff;
+    --sidebar-accent: rgba(255, 255, 255, 0.08);
+    --sidebar-accent-foreground: var(--dusk-200);
+    --sidebar-border: rgba(255, 255, 255, 0.06);
+    --sidebar-ring: var(--dusk-500);
+    --sidebar-muted-foreground: var(--sky-400);
+
+    --chart-1: var(--ink-500);
+    --chart-2: var(--dusk-500);
+    --chart-3: var(--success);
+    --chart-4: var(--info);
+    --chart-5: var(--sky-400);
+    --sidebar: var(--ink-600);
 }
 
 .dark {
-    --background: oklch(0.178 0.025 256.8);
-    --foreground: oklch(0.968 0.007 247.86);
-    --card: oklch(0.232 0.035 257.13);
-    --card-foreground: oklch(0.968 0.007 247.86);
-    --popover: oklch(0.232 0.035 257.13);
-    --popover-foreground: oklch(0.968 0.007 247.86);
-    --primary: oklch(0.554 0.195 255.13);
-    --primary-foreground: oklch(1 0 0);
-    --secondary: oklch(0.313 0.04 255.7);
-    --secondary-foreground: oklch(0.968 0.007 247.86);
-    --muted: oklch(0.313 0.04 255.7);
-    --muted-foreground: oklch(0.657 0.02 255.5);
-    --accent: oklch(0.313 0.04 255.7);
-    --accent-foreground: oklch(0.554 0.195 255.13);
-    --destructive: oklch(0.577 0.245 27.33);
-    --destructive-foreground: oklch(1 0 0);
-    --success: oklch(0.627 0.194 149.57);
-    --success-foreground: oklch(0.166 0.058 152.09);
-    --warning: oklch(0.681 0.162 75.83);
-    --warning-foreground: oklch(0.244 0.065 57.59);
-    --info: oklch(0.588 0.158 254.13);
-    --info-foreground: oklch(0.178 0.025 256.8);
-    --border: oklch(0.313 0.04 255.7);
-    --input: oklch(0.382 0.042 256.2);
-    --ring: oklch(0.554 0.195 255.13);
-    --sidebar-background: oklch(0.145 0.02 256.5);
-    --sidebar-foreground: oklch(0.929 0.011 252.84);
-    --sidebar-primary: oklch(0.852 0.119 85.84);
-    --sidebar-primary-foreground: oklch(0.145 0.02 256.5);
-    --sidebar-accent: oklch(1 0 0 / 10%);
-    --sidebar-accent-foreground: oklch(0.968 0.007 247.86);
-    --sidebar-border: oklch(1 0 0 / 15%);
-    --sidebar-ring: oklch(0.852 0.119 85.84);
-    --sidebar-muted-foreground: oklch(1 0 0 / 50%);
-    --chart-1: oklch(0.554 0.195 255.13);
-    --chart-2: oklch(0.627 0.194 149.57);
-    --chart-3: oklch(0.852 0.119 85.84);
-    --chart-4: oklch(0.588 0.158 254.13);
-    --chart-5: oklch(0.657 0.02 255.5);
-    --sidebar: hsl(240 5.9% 10%);
+    /* Dark mode is deferred; placeholder keeps shadcn happy if .dark class is toggled */
+    --background: var(--sky-900);
+    --foreground: var(--sky-100);
+    --card: var(--sky-800);
+    --card-foreground: var(--sky-100);
+    --popover: var(--sky-800);
+    --popover-foreground: var(--sky-100);
+    --primary: var(--dusk-400);
+    --primary-foreground: var(--sky-950);
+    --secondary: var(--sky-700);
+    --secondary-foreground: var(--sky-100);
+    --muted: var(--sky-700);
+    --muted-foreground: var(--sky-400);
+    --accent: var(--sky-700);
+    --accent-foreground: var(--dusk-200);
+    --destructive: #e04a4a;
+    --destructive-foreground: #ffffff;
+    --success: #4aba80;
+    --success-foreground: var(--sky-900);
+    --warning: #eba44a;
+    --warning-foreground: var(--sky-900);
+    --info: #4a9ae0;
+    --info-foreground: var(--sky-900);
+    --border: var(--sky-700);
+    --input: var(--sky-700);
+    --ring: var(--dusk-500);
+    --sidebar-background: var(--sky-950);
+    --sidebar-foreground: var(--sky-200);
+    --sidebar-primary: var(--dusk-500);
+    --sidebar-primary-foreground: #ffffff;
+    --sidebar-accent: rgba(255, 255, 255, 0.08);
+    --sidebar-accent-foreground: var(--dusk-200);
+    --sidebar-border: rgba(255, 255, 255, 0.06);
+    --sidebar-ring: var(--dusk-500);
+    --sidebar-muted-foreground: var(--sky-400);
 }
 
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
+    * {
+        @apply border-border outline-ring/50;
     }
-  body {
-    @apply bg-background text-foreground;
+    body {
+        @apply bg-background text-foreground;
+        font-family: var(--font-sans);
     }
-  html {
-    @apply font-sans;
+    html {
+        @apply font-sans;
     }
+}
+
+/* Cockpit utilities */
+.mono {
+    font-family: var(--font-mono);
+    font-feature-settings: "tnum", "ss01";
+    font-variant-numeric: tabular-nums;
+}
+.num {
+    font-variant-numeric: tabular-nums;
+}
+.cap {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+.font-display {
+    font-family: var(--font-display);
+}
+
+/* StatusDot pulse */
+@keyframes cpx-pulse {
+    0% { transform: scale(0.8); opacity: 0.4; }
+    70% { transform: scale(1.8); opacity: 0; }
+    100% { transform: scale(1.8); opacity: 0; }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { DM_Sans } from 'next/font/google'
+import { Archivo, DM_Sans, Geist_Mono } from 'next/font/google'
 import { cn } from '@/lib/utils'
 import { Toaster } from '@/components/ui/sonner'
 
@@ -8,7 +8,21 @@ export const metadata: Metadata = {
   description: 'Gestion de vols en montgolfiere',
 }
 
-const dmSans = DM_Sans({ subsets: ['latin'], variable: '--font-sans' })
+// DM Sans = body UI (doux, lisible)
+const dmSans = DM_Sans({ subsets: ['latin'], variable: '--font-sans', display: 'swap' })
+// Archivo = display (titres, wordmark, hero)
+const archivo = Archivo({
+  subsets: ['latin'],
+  variable: '--font-display',
+  display: 'swap',
+  weight: ['400', '500', '600', '700'],
+})
+// Geist Mono = data tabulaire (immats, heures, masses)
+const geistMono = Geist_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+})
 
 /**
  * Root layout: thin shell required by Next.js App Router.
@@ -18,7 +32,7 @@ const dmSans = DM_Sans({ subsets: ['latin'], variable: '--font-sans' })
  */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html className={cn('font-sans', dmSans.variable)}>
+    <html className={cn('font-sans', dmSans.variable, archivo.variable, geistMono.variable)}>
       <body>
         {children}
         <Toaster />

--- a/components/alerts-banner.tsx
+++ b/components/alerts-banner.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { AlertTriangle, ChevronRight } from 'lucide-react'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Badge } from '@/components/ui/badge'
+import { Chip } from '@/components/cockpit/chip'
 import type { Alert, AlertSeverity } from '@/lib/regulatory/alerts'
 
 const SEVERITY_VARIANT: Record<AlertSeverity, 'destructive' | 'critical' | 'warning' | 'outline'> =
@@ -16,8 +17,9 @@ const SEVERITY_VARIANT: Record<AlertSeverity, 'destructive' | 'critical' | 'warn
   }
 
 /**
- * Single-line alert summary that opens a Sheet with full details.
- * Only shows EXPIRED and CRITICAL alerts (WARNING is sidebar-only).
+ * Bandeau d'alertes reglementaires ("RegAlertBar" cockpit): bande pleine
+ * largeur sous la topbar, icone + comptage + chips severite + CTA. Ouvre
+ * une Sheet detaillee au clic.
  */
 export function AlertsBanner({ alerts }: { alerts: Alert[] }) {
   const t = useTranslations('alerts')
@@ -28,27 +30,36 @@ export function AlertsBanner({ alerts }: { alerts: Alert[] }) {
   const hasExpired = alerts.some((a) => a.severity === 'EXPIRED')
   const expiredCount = alerts.filter((a) => a.severity === 'EXPIRED').length
   const criticalCount = alerts.filter((a) => a.severity === 'CRITICAL').length
-  const parts: string[] = []
-  if (expiredCount > 0) parts.push(t('countExpired', { count: expiredCount }))
-  if (criticalCount > 0) parts.push(t('countCritical', { count: criticalCount }))
-  const summary = t('summary', { count: alerts.length, parts: parts.join(', ') })
+  const tone = hasExpired ? 'danger' : 'warn'
+  const barStyle = hasExpired
+    ? 'border-b border-[#f3c7c7] bg-[#fbe6e6] text-[#7a1717]'
+    : 'border-b border-[#f3dcaf] bg-[#fdf1d8] text-[#8a5300]'
 
   return (
     <>
-      <div className="px-4 pt-4">
-        <button
-          onClick={() => setOpen(true)}
-          className={`flex w-full items-center gap-3 rounded-lg border px-4 py-2.5 text-sm transition-colors ${
-            hasExpired
-              ? 'border-destructive/30 bg-destructive/5 text-destructive hover:bg-destructive/10'
-              : 'border-warning/30 bg-warning/5 text-warning hover:bg-warning/10'
-          }`}
-        >
-          <AlertTriangle className="h-4 w-4 shrink-0" />
-          <span className="flex-1 text-left font-medium">{summary}</span>
-          <ChevronRight className="h-4 w-4 shrink-0 opacity-50" />
-        </button>
-      </div>
+      <button
+        onClick={() => setOpen(true)}
+        className={`flex w-full items-center gap-3 px-5 py-2.5 text-left text-xs transition-colors hover:brightness-95 ${barStyle}`}
+      >
+        <AlertTriangle className="h-4 w-4 shrink-0" />
+        <span className="font-semibold">{t('count', { count: alerts.length })}</span>
+        <div className="flex shrink-0 gap-1.5">
+          {expiredCount > 0 && (
+            <Chip tone="danger" size="sm">
+              {t('countExpired', { count: expiredCount })}
+            </Chip>
+          )}
+          {criticalCount > 0 && (
+            <Chip tone={tone} size="sm">
+              {t('countCritical', { count: criticalCount })}
+            </Chip>
+          )}
+        </div>
+        <span className="ml-auto flex items-center gap-1 text-[11px] font-medium opacity-80">
+          {t('viewAll')}
+          <ChevronRight className="h-3.5 w-3.5" />
+        </span>
+      </button>
 
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetContent>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   History,
   User,
   LogOut,
+  Globe,
 } from 'lucide-react'
 import {
   Sidebar,
@@ -30,12 +31,14 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui/sidebar'
-import { Globe } from 'lucide-react'
+import { CalpaxWordmark } from '@/components/brand/calpax-wordmark'
+import { StatusDot } from '@/components/cockpit/status-dot'
 
 type NavItem = {
   key: string
   href: string
   icon: React.ComponentType<{ className?: string }>
+  badge?: number
 }
 
 type NavGroup = {
@@ -59,7 +62,17 @@ const roleAccess: Record<string, UserRole[]> = {
   audit: ['ADMIN_CALPAX', 'GERANT'],
 }
 
-export function AppSidebar({ userRole }: { userRole?: string }) {
+export function AppSidebar({
+  userRole,
+  exploitantName,
+  inFlightCount = 0,
+  pendingTicketsCount = 0,
+}: {
+  userRole?: string
+  exploitantName?: string | null
+  inFlightCount?: number
+  pendingTicketsCount?: number
+}) {
   const t = useTranslations('nav')
   const locale = useLocale()
   const pathname = usePathname()
@@ -72,7 +85,12 @@ export function AppSidebar({ userRole }: { userRole?: string }) {
     {
       label: t('groups.activity'),
       items: [
-        { key: 'billets', href: `/${locale}/billets`, icon: Ticket },
+        {
+          key: 'billets',
+          href: `/${locale}/billets`,
+          icon: Ticket,
+          badge: pendingTicketsCount > 0 ? pendingTicketsCount : undefined,
+        },
         { key: 'vols', href: `/${locale}/vols`, icon: Plane },
       ],
     },
@@ -107,33 +125,53 @@ export function AppSidebar({ userRole }: { userRole?: string }) {
     }))
     .filter((group) => group.items.length > 0)
 
+  const statusLine = buildStatusLine({ exploitantName, inFlightCount })
+
   return (
     <Sidebar>
       <SidebarHeader>
-        <div className="flex items-center gap-3 px-2 py-2 border-b border-sidebar-border pb-3 mb-1">
-          <img src="/logo.svg" alt="Calpax" className="h-7 w-7" />
-          <span className="text-lg font-bold text-sidebar-primary">Calpax</span>
+        <div className="border-b border-sidebar-border px-2 pb-3 pt-1">
+          <CalpaxWordmark
+            size={18}
+            subtitle={statusLine ?? undefined}
+            wordmarkClassName="text-dusk-200"
+          />
+          {inFlightCount > 0 && (
+            <div className="mono cap mt-2 flex items-center gap-1.5 text-[10px] text-dusk-300">
+              <StatusDot tone="dusk" pulse size={6} />
+              <span>{inFlightCount} en vol</span>
+            </div>
+          )}
         </div>
       </SidebarHeader>
       <SidebarContent>
         {filteredGroups.map((group) => (
           <SidebarGroup key={group.label ?? 'top'}>
             {group.label && (
-              <SidebarGroupLabel className="text-sidebar-primary/60 text-[10px] uppercase tracking-widest">
+              <SidebarGroupLabel className="cap text-[10px] text-sidebar-muted-foreground">
                 {group.label}
               </SidebarGroupLabel>
             )}
             <SidebarGroupContent>
               <SidebarMenu>
-                {group.items.map(({ key, href, icon: Icon }) => {
+                {group.items.map(({ key, href, icon: Icon, badge }) => {
                   const isActive =
                     pathname === href || (href !== `/${locale}` && pathname.startsWith(href))
                   return (
                     <SidebarMenuItem key={key}>
-                      <SidebarMenuButton isActive={isActive} asChild>
+                      <SidebarMenuButton
+                        isActive={isActive}
+                        asChild
+                        className="data-[active=true]:border-l-2 data-[active=true]:border-l-dusk-500 data-[active=true]:pl-2"
+                      >
                         <Link href={href}>
                           <Icon className="h-4 w-4" />
-                          <span>{t(key)}</span>
+                          <span className="flex-1">{t(key)}</span>
+                          {badge !== undefined && (
+                            <span className="mono rounded bg-dusk-500 px-1.5 py-px text-[10px] font-medium text-white">
+                              {badge}
+                            </span>
+                          )}
                         </Link>
                       </SidebarMenuButton>
                     </SidebarMenuItem>
@@ -184,4 +222,16 @@ export function AppSidebar({ userRole }: { userRole?: string }) {
       </SidebarFooter>
     </Sidebar>
   )
+}
+
+function buildStatusLine({
+  exploitantName,
+  inFlightCount,
+}: {
+  exploitantName?: string | null
+  inFlightCount: number
+}): string | null {
+  if (!exploitantName) return null
+  if (inFlightCount === 0) return exploitantName
+  return exploitantName
 }

--- a/components/brand/calpax-logo.tsx
+++ b/components/brand/calpax-logo.tsx
@@ -1,0 +1,27 @@
+import Image from 'next/image'
+import { cn } from '@/lib/utils'
+
+type CalpaxLogoProps = {
+  size?: number
+  className?: string
+  priority?: boolean
+}
+
+/**
+ * Brand mark Calpax — écusson hand-drawn + 2 ballons en réserve.
+ * Rendered via next/image pour bénéficier de la mise en cache et des dimensions imposées.
+ * Aspect ratio du SVG source: 575x540 ≈ 1.065.
+ */
+export function CalpaxLogo({ size = 32, className, priority = false }: CalpaxLogoProps) {
+  const height = Math.round(size * (540 / 575))
+  return (
+    <Image
+      src="/logo.svg"
+      alt=""
+      width={size}
+      height={height}
+      priority={priority}
+      className={cn('block shrink-0', className)}
+    />
+  )
+}

--- a/components/brand/calpax-wordmark.tsx
+++ b/components/brand/calpax-wordmark.tsx
@@ -1,0 +1,50 @@
+import { CalpaxLogo } from './calpax-logo'
+import { cn } from '@/lib/utils'
+
+type CalpaxWordmarkProps = {
+  size?: number
+  subtitle?: string | null
+  className?: string
+  wordmarkClassName?: string
+  subtitleClassName?: string
+  priority?: boolean
+}
+
+/**
+ * Logo + wordmark "Calpax" en Archivo 600. Utilisé dans la sidebar,
+ * le login et les entêtes de pages de marque.
+ *
+ * Le prop `subtitle` est optionnel (ex: nom de l'exploitant + pill "en vol").
+ */
+export function CalpaxWordmark({
+  size = 22,
+  subtitle,
+  className,
+  wordmarkClassName,
+  subtitleClassName,
+  priority = false,
+}: CalpaxWordmarkProps) {
+  return (
+    <div className={cn('inline-flex items-center gap-2.5', className)}>
+      <CalpaxLogo size={size + 6} priority={priority} />
+      <div className="flex flex-col leading-none">
+        <span
+          className={cn('font-display font-semibold tracking-tight', wordmarkClassName)}
+          style={{ fontSize: size + 2, letterSpacing: '-0.01em' }}
+        >
+          Calpax
+        </span>
+        {subtitle && (
+          <span
+            className={cn(
+              'mono cap mt-1.5 text-[10px] leading-none text-sky-400',
+              subtitleClassName,
+            )}
+          >
+            {subtitle}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/cockpit/chip.tsx
+++ b/components/cockpit/chip.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type ChipTone = 'neutral' | 'ok' | 'warn' | 'danger' | 'info' | 'dusk' | 'ink'
+type ChipSize = 'sm' | 'md'
+
+const TONE_STYLES: Record<ChipTone, { bg: string; fg: string; bd: string }> = {
+  neutral: { bg: 'var(--sky-100)', fg: 'var(--sky-600)', bd: 'var(--sky-200)' },
+  ok: { bg: '#e6f4ec', fg: '#1e6b44', bd: '#c9e6d5' },
+  warn: { bg: '#fdf1d8', fg: '#8a5300', bd: '#f3dcaf' },
+  danger: { bg: '#fbe6e6', fg: '#8a1c1c', bd: '#f3c7c7' },
+  info: { bg: '#e4eef8', fg: '#1a4a7e', bd: '#c8d9ea' },
+  dusk: { bg: 'var(--dusk-100)', fg: 'var(--dusk-700)', bd: 'var(--dusk-200)' },
+  ink: { bg: 'var(--ink-600)', fg: 'var(--sky-100)', bd: 'var(--ink-600)' },
+}
+
+type ChipProps = {
+  tone?: ChipTone
+  size?: ChipSize
+  icon?: React.ReactNode
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * Chip cockpit — rectangulaire (radius 4px), palette dédiée par tone.
+ * Distinct du Badge shadcn (pill rond) : utilisé pour statuts de vol,
+ * alertes réglementaires, étiquettes météo.
+ */
+export function Chip({ tone = 'neutral', size = 'sm', icon, className, children }: ChipProps) {
+  const palette = TONE_STYLES[tone]
+  const isSm = size === 'sm'
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 whitespace-nowrap font-medium',
+        isSm ? 'px-2 py-0.5 text-[11px]' : 'px-2.5 py-1 text-xs',
+        className,
+      )}
+      style={{
+        background: palette.bg,
+        color: palette.fg,
+        border: `1px solid ${palette.bd}`,
+        borderRadius: 4,
+        lineHeight: 1.4,
+      }}
+    >
+      {icon}
+      {children}
+    </span>
+  )
+}

--- a/components/cockpit/load-bar.tsx
+++ b/components/cockpit/load-bar.tsx
@@ -1,0 +1,51 @@
+import { cn } from '@/lib/utils'
+
+type LoadBarTone = 'ink' | 'dusk' | 'ok' | 'warn' | 'danger'
+
+const TONE_COLOR: Record<LoadBarTone, string> = {
+  ink: 'var(--ink-500)',
+  dusk: 'var(--dusk-500)',
+  ok: 'var(--success)',
+  warn: 'var(--warning)',
+  danger: 'var(--destructive)',
+}
+
+/**
+ * Jauge de remplissage horizontale — passagers, masse, carburant.
+ * `showText` affiche `value/max` en mono à droite.
+ */
+export function LoadBar({
+  value,
+  max,
+  tone = 'ink',
+  height = 6,
+  showText = false,
+  label,
+  className,
+}: {
+  value: number
+  max: number
+  tone?: LoadBarTone
+  height?: number
+  showText?: boolean
+  label?: string
+  className?: string
+}) {
+  const pct = max > 0 ? Math.min(1, Math.max(0, value / max)) : 0
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      {label && <span className="min-w-10 text-[11px] text-sky-500">{label}</span>}
+      <div className="relative flex-1 overflow-hidden rounded-full bg-sky-100" style={{ height }}>
+        <div
+          className="h-full transition-[width] duration-300"
+          style={{ width: `${pct * 100}%`, background: TONE_COLOR[tone] }}
+        />
+      </div>
+      {showText && (
+        <span className="mono text-[11px] text-sky-600">
+          {value}/{max}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/components/cockpit/mono-value.tsx
+++ b/components/cockpit/mono-value.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils'
+
+type MonoTone = 'default' | 'muted' | 'ok' | 'warn' | 'danger' | 'dusk' | 'inverted'
+
+const TONE_CLASS: Record<MonoTone, string> = {
+  default: 'text-sky-900',
+  muted: 'text-sky-500',
+  ok: 'text-[color:var(--success)]',
+  warn: 'text-[color:var(--warning)]',
+  danger: 'text-[color:var(--destructive)]',
+  dusk: 'text-dusk-700',
+  inverted: 'text-dusk-200',
+}
+
+export function MonoValue({
+  value,
+  unit,
+  tone = 'default',
+  size = 13,
+  className,
+}: {
+  value: React.ReactNode
+  unit?: string
+  tone?: MonoTone
+  size?: number
+  className?: string
+}) {
+  return (
+    <span
+      className={cn('mono', TONE_CLASS[tone], className)}
+      style={{ fontSize: size, lineHeight: 1.2 }}
+    >
+      {value}
+      {unit && <span className="ml-0.5 opacity-60">{unit}</span>}
+    </span>
+  )
+}

--- a/components/cockpit/sparkline.tsx
+++ b/components/cockpit/sparkline.tsx
@@ -1,0 +1,37 @@
+/**
+ * Sparkline lineaire — courbe de vent sur la journee, tendance remplissage, etc.
+ */
+export function Sparkline({
+  data,
+  width = 80,
+  height = 22,
+  color = 'var(--ink-500)',
+  fill = 'rgba(27,58,94,0.1)',
+  className,
+}: {
+  data: number[]
+  width?: number
+  height?: number
+  color?: string
+  fill?: string
+  className?: string
+}) {
+  if (data.length === 0) return null
+  const max = Math.max(...data, 1)
+  const min = Math.min(...data, 0)
+  const range = max - min || 1
+  const step = width / (data.length - 1 || 1)
+  const points = data.map(
+    (value, index) => [index * step, height - ((value - min) / range) * height] as const,
+  )
+  const linePath = points
+    .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)} ${y.toFixed(1)}`)
+    .join(' ')
+  const areaPath = `${linePath} L${width} ${height} L0 ${height} Z`
+  return (
+    <svg width={width} height={height} className={className} aria-hidden>
+      <path d={areaPath} fill={fill} />
+      <path d={linePath} stroke={color} strokeWidth="1.3" fill="none" />
+    </svg>
+  )
+}

--- a/components/cockpit/status-dot.tsx
+++ b/components/cockpit/status-dot.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@/lib/utils'
+
+type StatusTone = 'ok' | 'warn' | 'danger' | 'idle' | 'info' | 'dusk'
+
+const TONE_COLOR: Record<StatusTone, string> = {
+  ok: 'var(--success)',
+  warn: 'var(--warning)',
+  danger: 'var(--destructive)',
+  info: 'var(--info)',
+  idle: 'var(--sky-300)',
+  dusk: 'var(--dusk-500)',
+}
+
+export function StatusDot({
+  tone = 'ok',
+  pulse = false,
+  size = 8,
+  className,
+}: {
+  tone?: StatusTone
+  pulse?: boolean
+  size?: number
+  className?: string
+}) {
+  const color = TONE_COLOR[tone]
+  return (
+    <span
+      className={cn('relative inline-block shrink-0', className)}
+      style={{ width: size, height: size }}
+      aria-hidden
+    >
+      <span className="absolute inset-0 rounded-full" style={{ background: color }} />
+      {pulse && (
+        <span
+          className="absolute rounded-full"
+          style={{
+            inset: -Math.max(2, Math.floor(size / 2.5)),
+            background: color,
+            animation: 'cpx-pulse 1.8s ease-out infinite',
+          }}
+        />
+      )}
+    </span>
+  )
+}

--- a/components/cockpit/top-bar.tsx
+++ b/components/cockpit/top-bar.tsx
@@ -1,0 +1,46 @@
+import { Fragment, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+type TopBarProps = {
+  title: ReactNode
+  subtitle?: ReactNode
+  /** Fil d'ariane — affiché en petit au-dessus du titre */
+  crumbs?: ReactNode[]
+  /** Slot droit: boutons d'action, toggles, chips meteo... */
+  right?: ReactNode
+  className?: string
+}
+
+/**
+ * Topbar cockpit — à utiliser comme premier enfant d'une page du groupe `(app)`.
+ * Ne fait aucune hypothèse sur le layout : densité dense (min-height 58px),
+ * fond blanc sur border bas sky-100.
+ */
+export function TopBar({ title, subtitle, crumbs = [], right, className }: TopBarProps) {
+  return (
+    <div
+      className={cn(
+        'flex min-h-14 items-center gap-4 border-b border-sky-100 bg-card px-4 py-3 md:px-6',
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        {crumbs.length > 0 && (
+          <div className="mb-0.5 flex items-center gap-1.5 text-[11px] text-sky-500">
+            {crumbs.map((crumb, i) => (
+              <Fragment key={i}>
+                <span>{crumb}</span>
+                {i < crumbs.length - 1 && <span className="opacity-50">/</span>}
+              </Fragment>
+            ))}
+          </div>
+        )}
+        <div className="font-display text-lg font-medium leading-tight tracking-tight text-sky-900">
+          {title}
+        </div>
+        {subtitle && <div className="mt-0.5 text-xs text-sky-500">{subtitle}</div>}
+      </div>
+      {right && <div className="flex shrink-0 items-center gap-2">{right}</div>}
+    </div>
+  )
+}

--- a/components/cockpit/wind-arrow.tsx
+++ b/components/cockpit/wind-arrow.tsx
@@ -1,0 +1,43 @@
+/**
+ * Flèche de vent — direction en degrés (0 = Nord), vitesse en nœuds.
+ * Une barbule supplémentaire apparaît au-dessus de 12 kt (intensité).
+ */
+export function WindArrow({
+  direction = 0,
+  speed = 0,
+  size = 22,
+  className,
+}: {
+  direction?: number
+  speed?: number
+  size?: number
+  className?: string
+}) {
+  const intensity = Math.min(1, speed / 25)
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className={className}
+      aria-label={`Vent ${Math.round(speed)}kt ${Math.round(direction)}°`}
+    >
+      <g transform={`rotate(${direction} 12 12)`}>
+        <line x1="12" y1="20" x2="12" y2="5" stroke="currentColor" strokeWidth="1.4" />
+        <path
+          d="M8 9 L12 5 L16 9"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          fill="none"
+          strokeLinejoin="round"
+        />
+        {intensity > 0.5 && (
+          <>
+            <line x1="10" y1="14" x2="12" y2="12" stroke="currentColor" strokeWidth="1.2" />
+            <line x1="14" y1="14" x2="12" y2="12" stroke="currentColor" strokeWidth="1.2" />
+          </>
+        )}
+      </g>
+    </svg>
+  )
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -192,6 +192,8 @@
     "critical": "Critical",
     "daysRemaining": "{days, plural, =0 {Expired} one {# day} other {# days}}",
     "summary": "{count, plural, one {# regulatory alert} other {# regulatory alerts}} ({parts})",
+    "count": "{count, plural, one {# regulatory alert} other {# regulatory alerts}}",
+    "viewAll": "View all",
     "countExpired": "{count, plural, one {# expired} other {# expired}}",
     "countCritical": "{count, plural, one {# critical} other {# critical}}",
     "camoExpiry": "CAMO certificate",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -192,6 +192,8 @@
     "critical": "Critique",
     "daysRemaining": "{days, plural, =0 {Expiré} one {# jour} other {# jours}}",
     "summary": "{count, plural, one {# alerte réglementaire} other {# alertes réglementaires}} ({parts})",
+    "count": "{count, plural, one {# alerte réglementaire} other {# alertes réglementaires}}",
+    "viewAll": "Voir tout",
     "countExpired": "{count, plural, one {# expirée} other {# expirées}}",
     "countCritical": "{count, plural, one {# critique} other {# critiques}}",
     "camoExpiry": "Certificat CAMO",


### PR DESCRIPTION
## Summary

**Phase 1 (fondations)** du chantier de refonte UI « Crépuscule cockpit » — direction retenue dans l'itération design d'avril 2026 (palette bleu nuit + couchant orangé, typo Archivo, logo hand-drawn).

Ce PR pose toutes les briques réutilisables que les phases suivantes vont composer : tokens, polices, composants brand, primitives cockpit, shell (sidebar + topbar + alert bar).

## Phase 1 — contenu

- [x] **1.1 — Tokens** (`app/globals.css`) : palette hex `sky-0..950` / `ink-500..800` / `dusk-50..700` + sémantiques `--success` / `--warning` / `--destructive` / `--info`. Sidebar remappée sur `ink-600` (#13304e — « dark adouci », option A du user). Utilitaires `.mono` / `.num` / `.cap` / `.font-display`. Keyframe `cpx-pulse`.
- [x] **1.2 — Polices** (`app/layout.tsx`) : Archivo (display), DM Sans (body), Geist Mono (data) chargées simultanément via `next/font/google`, exposées sur `--font-display` / `--font-sans` / `--font-mono`.
- [x] **1.3 — Brand** (`components/brand/`) : `CalpaxLogo` (next/image wrapped, SVG hand-drawn déjà dans `public/logo.svg`) + `CalpaxWordmark` (logo + Archivo 600 lockup, subtitle optionnel).
- [x] **1.4 — Primitives cockpit** (`components/cockpit/`) : `StatusDot` (pulse), `Chip` (7 tones), `MonoValue`, `LoadBar`, `WindArrow`, `Sparkline`, `TopBar`.
- [x] **1.5 — AppSidebar** : header `CalpaxWordmark` avec subtitle = nom exploitant, pill « en vol » masquée tant que `inFlightCount === 0` (wiring GPS live plus tard). Badge billets dynamique (`pendingTicketsCount`). Active nav item avec border-left 2px `dusk-500`.
- [x] **1.6 — TopBar** : composant autonome `components/cockpit/top-bar.tsx` — les pages l'adopteront au fur et à mesure (Phase 3/4). Header mobile sticky utilise désormais `CalpaxWordmark`.
- [x] **1.7 — AlertsBanner → RegAlertBar** : bande cockpit pleine largeur colorée par sévérité (danger/warn), chips de décompte, CTA « voir tout ». Sheet détaillée conservée. Nouvelles clés i18n `alerts.count`, `alerts.viewAll` (fr/en).

## Décisions consignées

- Typo **plus douce** : Archivo pour le display uniquement, DM Sans reste en body UI
- Sidebar **option A** : `ink-600` (#13304e) — plus doux que le `#091a30` pur du mockup
- Pill « en vol » : rendue seulement quand `inFlightCount > 0` (GPS live différé)
- Per-tenant `logoUrl` (PDFs) : conservé, indépendant de la brand Calpax
- Dark mode : tokens placeholder en place, reskin dédié différé

## Phases à suivre (nouvelles PRs)

- [ ] **Phase 2** — Login V1 Editorial (`auth/signin/page.tsx`)
- [ ] **Phase 3** — Dashboard jour J cockpit (`(app)/page.tsx` + `flight-card.tsx`)
- [ ] **Phase 4** — Planning hebdo (`week-grid.tsx`) + détail vol (`vols/[id]/page.tsx`)

## Test plan

- [x] `pnpm run typecheck` — propre sur tous les fichiers touchés (erreurs restantes pré-existantes dans `tests/integration/*`)
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests passent
- [x] `pnpm run lint` — aucun nouveau warning
- [ ] Vercel preview : vérifier visuellement la sidebar (ink-600 + accent orange), le header mobile, le bandeau d'alertes
- [ ] Smoke manuel : navigation entre pages, badge billets, sidebar toggle mobile

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32