### PR TITLE
refonte(phase 3): dashboard cockpit + FlightCard restyle

### DIFF
--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -12,6 +12,8 @@ import { buildBallonAlerts, buildPiloteAlerts, sortAlerts } from '@/lib/regulato
 import { safeDecryptInt } from '@/lib/crypto'
 import { AlertsBanner } from '@/components/alerts-banner'
 import { FlightCard, type FlightCardData } from '@/components/flight-card'
+import { KpiRow, KpiTile } from '@/components/cockpit/kpi-tile'
+import { WindArrow } from '@/components/cockpit/wind-arrow'
 import { Button } from '@/components/ui/button'
 import type { Prisma } from '@prisma/client'
 import type { WeatherForecast, WeatherSummary } from '@/lib/weather/types'
@@ -193,30 +195,73 @@ export default async function HomePage({ params }: Props) {
       }
     })
 
+    // 6. Derive cockpit KPIs from today's data
+    const nextFlight = cards[0] ?? null
+    const maxWindKt = cards.reduce(
+      (max, c) => (c.weather && c.weather.maxWindKt > max ? c.weather.maxWindKt : max),
+      0,
+    )
+    const paxBooked = cards.reduce((sum, c) => sum + c.passagerCount, 0)
+    const paxSeats = cards.reduce((sum, c) => sum + c.passagerMax, 0)
+
+    const dateLabel = today.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-US', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+
     return (
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">{t('title')}</h1>
-            <p className="text-sm text-muted-foreground">
-              {today.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-US', {
-                weekday: 'long',
-                day: 'numeric',
-                month: 'long',
-                year: 'numeric',
-              })}
-              {' — '}
-              {t('flightCount', { count: vols.length })}
-            </p>
+        {/* Header */}
+        <header className="space-y-1">
+          <div className="mono cap text-[11px] text-dusk-700">{t('kicker')}</div>
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <h1 className="font-display text-3xl font-semibold tracking-tight text-sky-900">
+              {t('title')}
+            </h1>
+            <div className="mono text-[11px] text-sky-500">
+              <span className="cap">{dateLabel}</span>
+              <span className="mx-2 opacity-50">·</span>
+              <span>{t('flightCount', { count: vols.length })}</span>
+            </div>
           </div>
-        </div>
+        </header>
+
+        {/* KPI row */}
+        <KpiRow>
+          <KpiTile
+            label={t('kpi.nextFlight')}
+            value={nextFlight ? CRENEAU_LABELS[nextFlight.creneau] : t('kpi.nextFlightEmpty')}
+            sub={nextFlight ? `${nextFlight.ballonImmat} · ${nextFlight.ballonNom}` : null}
+            tone={nextFlight ? 'dusk' : 'default'}
+          />
+          <KpiTile
+            label={t('kpi.wind')}
+            value={maxWindKt > 0 ? `${maxWindKt}` : t('kpi.windEmpty')}
+            sub={maxWindKt > 0 ? t('kpi.windUnit') : null}
+            icon={maxWindKt > 0 ? <WindArrow speed={maxWindKt} size={16} /> : null}
+            tone={maxWindKt >= seuilVent ? 'warn' : 'default'}
+          />
+          <KpiTile
+            label={t('kpi.pax')}
+            value={t('kpi.paxCovered', { booked: paxBooked, seats: paxSeats })}
+            tone="default"
+          />
+          <KpiTile
+            label={t('kpi.flights')}
+            value={vols.length}
+            sub={t('kpi.flightsSub')}
+            tone="default"
+          />
+        </KpiRow>
 
         {criticalAlerts.length > 0 && <AlertsBanner alerts={criticalAlerts} />}
 
         {vols.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <Plane className="h-12 w-12 text-muted-foreground/30 mb-4" />
-            <p className="text-muted-foreground mb-4">{t('noFlights')}</p>
+          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-sky-200 bg-card py-16 text-center">
+            <Plane className="mb-4 h-12 w-12 text-sky-300" aria-hidden />
+            <p className="mb-4 text-sky-500">{t('noFlights')}</p>
             <Button asChild variant="outline">
               <Link href={`/${locale}/vols`}>{t('goToPlanning')}</Link>
             </Button>

--- a/components/cockpit/kpi-tile.tsx
+++ b/components/cockpit/kpi-tile.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type KpiTone = 'default' | 'dusk' | 'ok' | 'warn' | 'danger'
+
+const VALUE_TONE: Record<KpiTone, string> = {
+  default: 'text-sky-900',
+  dusk: 'text-dusk-700',
+  ok: 'text-[color:var(--success)]',
+  warn: 'text-[color:var(--warning)]',
+  danger: 'text-[color:var(--destructive)]',
+}
+
+type KpiTileProps = {
+  label: string
+  value: React.ReactNode
+  sub?: React.ReactNode
+  icon?: React.ReactNode
+  tone?: KpiTone
+  className?: string
+}
+
+/**
+ * Tuile cockpit — label en cap mono, valeur en Archivo mono large, sublabel.
+ * Utilisée en rangée pour afficher les KPIs du dashboard jour J.
+ */
+export function KpiTile({ label, value, sub, icon, tone = 'default', className }: KpiTileProps) {
+  return (
+    <div className={cn('relative flex flex-col gap-1 px-4 py-3', className)}>
+      <div className="mono cap flex items-center gap-1.5 text-[10px] text-sky-500">
+        <span>{label}</span>
+      </div>
+      <div className="flex items-end gap-2">
+        <span
+          className={cn(
+            'mono text-[24px] font-semibold leading-none tracking-tight',
+            VALUE_TONE[tone],
+          )}
+        >
+          {value}
+        </span>
+        {icon && <span className="mb-0.5 text-sky-500">{icon}</span>}
+      </div>
+      {sub && <div className="text-[11px] text-sky-500">{sub}</div>}
+    </div>
+  )
+}
+
+/**
+ * Conteneur horizontal avec séparateurs pour une rangée de KpiTile.
+ */
+export function KpiRow({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-2 overflow-hidden rounded-lg border border-sky-100 bg-card shadow-[var(--sh-1)] lg:grid-cols-4',
+        'divide-x divide-y divide-sky-100 lg:divide-y-0',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/flight-card.tsx
+++ b/components/flight-card.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
-import { Wind, Thermometer, AlertTriangle } from 'lucide-react'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent } from '@/components/ui/card'
+import { AlertTriangle, Thermometer } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Chip } from '@/components/cockpit/chip'
+import { LoadBar } from '@/components/cockpit/load-bar'
+import { MonoValue } from '@/components/cockpit/mono-value'
+import { WindArrow } from '@/components/cockpit/wind-arrow'
 import { cn } from '@/lib/utils'
 import type { UserRole } from '@/lib/context'
 
@@ -47,33 +49,24 @@ type Props = {
 
 const CAN_ORGANIZE: UserRole[] = ['ADMIN_CALPAX', 'GERANT']
 
-function capacityColorClass(count: number, max: number): string {
-  if (max === 0) return ''
-  if (count > max) return 'text-red-700'
-  if (count / max >= 0.8) return 'text-amber-700'
-  return 'text-green-700'
+const STATUT_CHIP: Record<string, Parameters<typeof Chip>[0]['tone']> = {
+  PLANIFIE: 'neutral',
+  CONFIRME: 'info',
+  TERMINE: 'ok',
+  ARCHIVE: 'neutral',
+  ANNULE: 'danger',
 }
 
-type BadgeVariant = 'outline' | 'secondary' | 'default' | 'destructive' | 'warning'
-
-const STATUT_VARIANT: Record<string, BadgeVariant> = {
-  PLANIFIE: 'outline',
-  CONFIRME: 'secondary',
-  TERMINE: 'default',
-  ARCHIVE: 'default',
-  ANNULE: 'destructive',
+const MASS_TONE: Record<MassBudget['status'], Parameters<typeof LoadBar>[0]['tone']> = {
+  OK: 'ok',
+  WARNING: 'warn',
+  OVER: 'danger',
 }
 
-const MASS_COLORS: Record<MassBudget['status'], string> = {
-  OK: 'text-green-700',
-  WARNING: 'text-amber-700',
-  OVER: 'text-red-700',
-}
-
-const MASS_VARIANT: Record<MassBudget['status'], BadgeVariant> = {
-  OK: 'secondary',
-  WARNING: 'warning',
-  OVER: 'destructive',
+const MASS_CHIP: Record<MassBudget['status'], Parameters<typeof Chip>[0]['tone']> = {
+  OK: 'ok',
+  WARNING: 'warn',
+  OVER: 'danger',
 }
 
 const MASS_LABEL_KEY: Record<MassBudget['status'], string> = {
@@ -82,10 +75,20 @@ const MASS_LABEL_KEY: Record<MassBudget['status'], string> = {
   OVER: 'massOver',
 }
 
-const GONOGO_VARIANT: Record<WeatherSummary['goNogo'], BadgeVariant> = {
-  GO: 'secondary',
-  NOGO: 'destructive',
-  MARGINAL: 'warning',
+const GONOGO_CHIP: Record<WeatherSummary['goNogo'], Parameters<typeof Chip>[0]['tone']> = {
+  GO: 'ok',
+  NOGO: 'danger',
+  MARGINAL: 'warn',
+}
+
+const CAPACITY_TONE: (c: number, m: number) => Parameters<typeof LoadBar>[0]['tone'] = (
+  count,
+  max,
+) => {
+  if (max === 0) return 'ink'
+  if (count > max) return 'danger'
+  if (count / max >= 0.8) return 'warn'
+  return 'ok'
 }
 
 export function FlightCard({ flight, locale, showActions = true, userRole }: Props) {
@@ -94,113 +97,125 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
   const canOrganize = !!userRole && CAN_ORGANIZE.includes(userRole)
 
   return (
-    <Card className={cn(flight.meteoAlert && 'border-amber-400 bg-amber-50/50')}>
-      <CardContent className="p-4 space-y-3">
-        {/* Header: créneau + statut */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Badge variant="outline" className="text-xs">
-              {tv(`creneau.${flight.creneau}`)}
-            </Badge>
-            <span className="text-sm font-semibold">{flight.ballonNom}</span>
-            <span className="text-xs text-muted-foreground">({flight.ballonImmat})</span>
-          </div>
-          <Badge variant={STATUT_VARIANT[flight.statut] ?? 'outline'}>
-            {tv(`statut.${flight.statut}`)}
-          </Badge>
+    <article
+      className={cn(
+        'flex flex-col gap-4 rounded-lg border border-sky-100 bg-card p-4 shadow-[var(--sh-1)]',
+        flight.meteoAlert && 'border-dusk-200',
+      )}
+    >
+      {/* Meteo alert strip */}
+      {flight.meteoAlert && (
+        <div
+          role="status"
+          className="-mx-4 -mt-4 flex items-center gap-2 border-b border-dusk-200 bg-dusk-50 px-4 py-2 text-xs font-medium text-dusk-700"
+        >
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          <span>{t('meteoAlert')}</span>
         </div>
+      )}
 
-        {/* Crew + site */}
-        <div className="grid grid-cols-2 gap-2 text-sm">
-          <div>
-            <span className="text-xs text-muted-foreground">{tv('fields.pilote')}</span>
-            <p className="font-medium">{flight.piloteNom}</p>
-          </div>
-          <div>
-            <span className="text-xs text-muted-foreground">{tv('fields.equipier')}</span>
-            <p className="font-medium">{flight.equipierNom ?? '—'}</p>
-          </div>
-          <div>
-            <span className="text-xs text-muted-foreground">{tv('fields.lieuDecollage')}</span>
-            <p className="font-medium">{flight.siteDeco ?? '—'}</p>
-          </div>
-          <div>
-            <span className="text-xs text-muted-foreground">{t('capacity')}</span>
-            <p
-              className={cn(
-                'font-medium',
-                capacityColorClass(flight.passagerCount, flight.passagerMax),
-              )}
-            >
-              {flight.passagerCount}/{flight.passagerMax}
-            </p>
-          </div>
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Chip tone="dusk" size="sm">
+            {tv(`creneau.${flight.creneau}`)}
+          </Chip>
+          <MonoValue value={flight.ballonImmat} size={12} tone="muted" />
+          <span className="font-display text-sm font-medium text-sky-900">{flight.ballonNom}</span>
         </div>
+        <Chip tone={STATUT_CHIP[flight.statut] ?? 'neutral'} size="sm">
+          {tv(`statut.${flight.statut}`)}
+        </Chip>
+      </div>
 
-        {/* Mass budget */}
-        {flight.massBudget ? (
-          <div className="flex items-center gap-3 text-sm rounded-md bg-muted/50 px-3 py-2">
-            <span className="text-muted-foreground">{t('massLabel')}</span>
-            <span className={cn('font-semibold', MASS_COLORS[flight.massBudget.status])}>
-              {flight.massBudget.totalWeight} kg / {flight.massBudget.maxPayload} kg
-            </span>
-            <Badge variant={MASS_VARIANT[flight.massBudget.status]} className="text-xs">
+      {/* Meta grid 2x2 */}
+      <div className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+        <MetaField label={tv('fields.pilote')} value={flight.piloteNom} />
+        <MetaField label={tv('fields.equipier')} value={flight.equipierNom ?? '—'} />
+        <MetaField label={tv('fields.lieuDecollage')} value={flight.siteDeco ?? '—'} />
+        <div className="space-y-1">
+          <div className="mono cap text-[10px] text-sky-500">{t('capacity')}</div>
+          <LoadBar
+            value={flight.passagerCount}
+            max={flight.passagerMax}
+            tone={CAPACITY_TONE(flight.passagerCount, flight.passagerMax)}
+            showText
+          />
+        </div>
+      </div>
+
+      {/* Mass budget */}
+      {flight.massBudget ? (
+        <div className="space-y-1.5 rounded-md bg-sky-50 px-3 py-2.5">
+          <div className="flex items-center justify-between gap-2">
+            <span className="mono cap text-[10px] text-sky-500">{t('massLabel')}</span>
+            <Chip tone={MASS_CHIP[flight.massBudget.status]} size="sm">
               {t(MASS_LABEL_KEY[flight.massBudget.status])}
-            </Badge>
+            </Chip>
           </div>
-        ) : (
-          <div className="text-xs text-muted-foreground italic">{t('massUnavailable')}</div>
-        )}
-
-        {/* Weather */}
-        {flight.weather && (
-          <div
-            className={cn(
-              'rounded-md px-3 py-2 text-sm space-y-1.5',
-              flight.meteoAlert ? 'bg-amber-100' : 'bg-muted/50',
-            )}
-          >
-            <div className="flex items-center gap-4 flex-wrap">
-              <span className="text-muted-foreground">
-                {tv(`creneau.${flight.creneau}`)} ({flight.weather.creneauRange})
-              </span>
-              <div className="flex items-center gap-1">
-                <Wind className="h-4 w-4 text-muted-foreground" />
-                <span>
-                  {flight.weather.maxWindKt} km/h ({flight.weather.maxWindAltitude})
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <Thermometer className="h-4 w-4 text-muted-foreground" />
-                <span>{flight.weather.avgTemperature}°C</span>
-              </div>
-              <Badge variant={GONOGO_VARIANT[flight.weather.goNogo]}>
-                {t(`goNogo.${flight.weather.goNogo}`)}
-              </Badge>
-            </div>
-            {flight.meteoAlert && (
-              <div role="status" className="flex items-center gap-2 text-amber-900 font-medium">
-                <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
-                <span>{t('meteoAlert')}</span>
-              </div>
-            )}
+          <LoadBar
+            value={flight.massBudget.totalWeight}
+            max={flight.massBudget.maxPayload}
+            tone={MASS_TONE[flight.massBudget.status]}
+            height={6}
+          />
+          <div className="flex justify-between text-[11px]">
+            <MonoValue value={flight.massBudget.totalWeight} unit="kg" size={11} />
+            <MonoValue value={flight.massBudget.maxPayload} unit="kg" tone="muted" size={11} />
           </div>
-        )}
+        </div>
+      ) : (
+        <div className="text-xs italic text-sky-400">{t('massUnavailable')}</div>
+      )}
 
-        {/* Actions */}
-        {showActions && (
-          <div className="flex flex-wrap gap-2 pt-1">
-            <Button asChild size="sm" variant="outline">
-              <Link href={`/${locale}/vols/${flight.id}`}>{tv('detail')}</Link>
+      {/* Weather strip */}
+      {flight.weather && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md bg-sky-50 px-3 py-2 text-sm">
+          <span className="mono cap text-[10px] text-sky-500">
+            {tv(`creneau.${flight.creneau}`)} · {flight.weather.creneauRange}
+          </span>
+          <div className="flex items-center gap-1.5 text-sky-700">
+            <WindArrow
+              direction={0}
+              speed={flight.weather.maxWindKt}
+              size={16}
+              className="text-sky-500"
+            />
+            <MonoValue value={flight.weather.maxWindKt} unit="kt" size={12} />
+            <span className="text-[10px] text-sky-400">({flight.weather.maxWindAltitude})</span>
+          </div>
+          <div className="flex items-center gap-1 text-sky-700">
+            <Thermometer className="h-3.5 w-3.5 text-sky-500" aria-hidden />
+            <MonoValue value={flight.weather.avgTemperature} unit="°C" size={12} />
+          </div>
+          <Chip tone={GONOGO_CHIP[flight.weather.goNogo]} size="sm" className="ml-auto">
+            {t(`goNogo.${flight.weather.goNogo}`)}
+          </Chip>
+        </div>
+      )}
+
+      {/* Actions */}
+      {showActions && (
+        <div className="flex flex-wrap gap-2 pt-0.5">
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/${locale}/vols/${flight.id}`}>{tv('detail')}</Link>
+          </Button>
+          {canOrganize && flight.statut === 'PLANIFIE' && (
+            <Button asChild size="sm">
+              <Link href={`/${locale}/vols/${flight.id}/organiser`}>{tv('organiser')}</Link>
             </Button>
-            {canOrganize && flight.statut === 'PLANIFIE' && (
-              <Button asChild size="sm" variant="outline">
-                <Link href={`/${locale}/vols/${flight.id}/organiser`}>{tv('organiser')}</Link>
-              </Button>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+          )}
+        </div>
+      )}
+    </article>
+  )
+}
+
+function MetaField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-0.5 min-w-0">
+      <div className="mono cap text-[10px] text-sky-500">{label}</div>
+      <div className="truncate font-medium text-sky-900">{value}</div>
+    </div>
   )
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -702,6 +702,18 @@
       "NOGO": "NO-GO",
       "MARGINAL": "Marginal"
     },
+    "kicker": "Today's cockpit",
+    "kpi": {
+      "nextFlight": "NEXT FLIGHT",
+      "nextFlightEmpty": "—",
+      "wind": "MAX WIND",
+      "windEmpty": "—",
+      "windUnit": "kt",
+      "pax": "PAX",
+      "paxCovered": "{booked}/{seats}",
+      "flights": "FLIGHTS",
+      "flightsSub": "Today"
+    },
     "meteoAlert": "Wind forecast above threshold",
     "meteoAlertAction": "Cancel this flight?",
     "cancelMeteo": "Cancel (weather)",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -705,7 +705,19 @@
     "meteoAlert": "Vent prévu au-dessus du seuil",
     "meteoAlertAction": "Annuler ce vol ?",
     "cancelMeteo": "Annuler (météo)",
-    "cancelMeteoConfirm": "Annuler ce vol pour raison météo ? Les passagers seront désaffectés et les contacts notifiés par email."
+    "cancelMeteoConfirm": "Annuler ce vol pour raison météo ? Les passagers seront désaffectés et les contacts notifiés par email.",
+    "kicker": "Cockpit du jour",
+    "kpi": {
+      "nextFlight": "PROCHAIN VOL",
+      "nextFlightEmpty": "—",
+      "wind": "VENT MAX",
+      "windEmpty": "—",
+      "windUnit": "kt",
+      "pax": "PAX",
+      "paxCovered": "{booked}/{seats}",
+      "flights": "VOLS",
+      "flightsSub": "Aujourd'hui"
+    }
   },
   "cancellation": {
     "emailSubjectPayeur": "Vol annulé — {date}",


### PR DESCRIPTION
## Summary

**Phase 3** du chantier refonte UI — dashboard « cockpit jour J ».

Rewrite la page `/` (`(app)/page.tsx`) et le composant partagé `FlightCard` pour adopter la densité cockpit du design bundle, sans toucher au pipeline de données.

## Changements visuels

### Dashboard header
- Kicker mono caps `COCKPIT DU JOUR` en dusk-700
- Titre Archivo 3xl + métadonnées mono à droite (date longue + compteur vols)

### KPI row (nouveau)
4 tuiles dans un `KpiRow` (card bordée, colonnes lg: 4 / default: 2) :

| Tuile | Valeur | Source |
|---|---|---|
| **PROCHAIN VOL** (dusk) | `MATIN/SOIR` | premier vol trié par créneau |
| **VENT MAX** (warn si ≥ seuil) | `N kt` + WindArrow | max sur météo des créneaux du jour |
| **PAX** | `booked/seats` | somme `passagerCount` / `passagerMax` |
| **VOLS** | `vols.length` | compteur |

Em-dash en cas de données absentes (pas de vol, pas de météo).

### FlightCard (restyle complet)
- Border sky-100 + shadow-1 au lieu de Card/CardContent shadcn
- Header : Chip dusk `MATIN/SOIR` + immat mono + ballon Archivo + Chip statut
- Meta 2×2 : pilote / équipier / site + LoadBar capacité (ok/warn/danger par remplissage)
- Devis de masse : LoadBar + valeurs mono + chip sévérité
- Météo : WindArrow + valeurs mono + altitude + chip GO/NOGO
- Alerte météo : strip top dusk-50 en bleed (–mx-4 –mt-4) au lieu du frame amber
- Actions : Detail (outline) + Organise (primary sky-900)

## Préservé
- Pipeline données identique : `db.vol.findMany` avec `buildVolWhereForRole`, `getWeather`, `computeMassBudget`, `buildBallonAlerts/PiloteAlerts`
- `FlightCardData` unchanged (même props, utilisé aussi par `vols/page.tsx` — auto-reskinnage)
- RBAC `canOrganize` préservé (`ADMIN_CALPAX`, `GERANT`)

## Nouveaux fichiers
- `components/cockpit/kpi-tile.tsx` — `KpiTile` + `KpiRow`

## i18n (fr/en)
Sous `dashboard.*` :
- `kicker` — `"Cockpit du jour"` / `"Today's cockpit"`
- `kpi.{nextFlight, nextFlightEmpty, wind, windEmpty, windUnit, pax, paxCovered, flights, flightsSub}`

## Reporté à Phase 4
- Fenêtre GO/HOLD/NO-GO timeline
- Section flotte (row ballons/statut/prochain vol)
- 7 prochains vols (mini-table)

Priorité Phase 4 est Planning hebdo + détail vol. Ces 3 blocs dashboard cockpit iront en Phase 3.5 si besoin.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : KPI row desktop + mobile, FlightCard restylée (normal / meteo-alert / mass dépassement / capacity > max)

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32