### PR TITLE
refonte(phase 4): weekly planning + vol detail bandeau

### DIFF
--- a/app/[locale]/(app)/vols/[id]/page.tsx
+++ b/app/[locale]/(app)/vols/[id]/page.tsx
@@ -139,41 +139,62 @@ export default async function VolDetailPage({ params }: Props) {
 
     return (
       <div className="space-y-6 pb-20 md:pb-0">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
+        {/* Cockpit bandeau */}
+        <header className="space-y-3 rounded-lg bg-sky-900 p-5 text-sky-100 shadow-[var(--sh-2)]">
+          <div className="flex flex-wrap items-center justify-between gap-3">
             <Link
               href={`/${locale}/vols`}
-              className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))}
+              className="mono cap text-[11px] text-dusk-200 transition-colors hover:text-dusk-100"
             >
-              {t('backToList')}
+              &larr; {t('backToList')}
             </Link>
-            <h1 className="text-3xl font-bold tracking-tight">
-              {formatDateFr(vol.date)} — {t(`creneau.${vol.creneau}`)}
-            </h1>
-            <Badge variant={statutVariant(vol.statut)} className={cn(statutClassName(vol.statut))}>
-              {t(`statut.${vol.statut}`)}
-            </Badge>
+            <div className="mono cap text-[10px] text-sky-400">{t('detailKicker')}</div>
           </div>
-          <div className="flex gap-2">
-            {canEdit && (vol.statut === 'PLANIFIE' || vol.statut === 'CONFIRME') && (
-              <Link
-                href={`/${locale}/vols/${id}/edit`}
-                className={buttonVariants({ variant: 'outline' })}
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div className="space-y-1">
+              <h1 className="font-display text-3xl font-semibold leading-tight tracking-tight text-dusk-200">
+                {formatDateFr(vol.date)}{' '}
+                <span className="text-white/80">· {t(`creneau.${vol.creneau}`)}</span>
+              </h1>
+              <div className="mono flex items-center gap-3 text-[12px] text-sky-300">
+                <span>{vol.ballon.immatriculation}</span>
+                <span className="opacity-40">·</span>
+                <span>{vol.ballon.nom}</span>
+                <span className="opacity-40">·</span>
+                <span>
+                  {vol.pilote.prenom} {vol.pilote.nom}
+                </span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge
+                variant={statutVariant(vol.statut)}
+                className={cn(statutClassName(vol.statut))}
               >
-                {t('edit')}
-              </Link>
-            )}
-            {canEdit && vol.statut === 'PLANIFIE' && (
-              <Link
-                href={`/${locale}/vols/${id}/organiser`}
-                className={buttonVariants({ variant: 'outline' })}
-              >
-                {t('organiser')}
-              </Link>
-            )}
+                {t(`statut.${vol.statut}`)}
+              </Badge>
+              {canEdit && (vol.statut === 'PLANIFIE' || vol.statut === 'CONFIRME') && (
+                <Link
+                  href={`/${locale}/vols/${id}/edit`}
+                  className={cn(
+                    buttonVariants({ variant: 'outline', size: 'sm' }),
+                    'border-sky-600 bg-sky-800 text-sky-100 hover:bg-sky-700 hover:text-white',
+                  )}
+                >
+                  {t('edit')}
+                </Link>
+              )}
+              {canEdit && vol.statut === 'PLANIFIE' && (
+                <Link
+                  href={`/${locale}/vols/${id}/organiser`}
+                  className={cn(buttonVariants({ size: 'sm' }))}
+                >
+                  {t('organiser')}
+                </Link>
+              )}
+            </div>
           </div>
-        </div>
+        </header>
 
         {/* Action buttons */}
         <div className="flex items-center gap-3 flex-wrap">

--- a/app/[locale]/(app)/vols/page.tsx
+++ b/app/[locale]/(app)/vols/page.tsx
@@ -4,7 +4,6 @@ import { requireAuth } from '@/lib/auth/requireAuth'
 import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
 import { buttonVariants } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { WeekGrid } from '@/components/week-grid'
 import type { VolSummary } from '@/components/week-grid'
@@ -119,15 +118,20 @@ export default async function VolsPage({ params, searchParams }: Props) {
 
     return (
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold tracking-tight">{t('title')}</h1>
+        <header className="flex flex-wrap items-end justify-between gap-3">
+          <div className="space-y-1">
+            <div className="mono cap text-[11px] text-dusk-700">{t('kicker')}</div>
+            <h1 className="font-display text-3xl font-semibold tracking-tight text-sky-900">
+              {t('title')}
+            </h1>
+          </div>
           <Link
             href={`/${locale}/vols/create`}
             className={cn(buttonVariants({ variant: 'default' }))}
           >
             {t('new')}
           </Link>
-        </div>
+        </header>
 
         {/* Mobile: stacked flight cards */}
         <div className="md:hidden space-y-3">
@@ -151,18 +155,14 @@ export default async function VolsPage({ params, searchParams }: Props) {
 
         {/* Desktop: week grid */}
         <div className="hidden md:block">
-          <Card>
-            <CardContent className="p-4">
-              <WeekGrid
-                weekStart={weekStartStr}
-                vols={weekVols}
-                locale={locale}
-                todayMonday={getMondayOfWeek(todayStr)}
-                emptyActionLabel={t('createFirst')}
-                emptyActionHref={`/${locale}/vols/create`}
-              />
-            </CardContent>
-          </Card>
+          <WeekGrid
+            weekStart={weekStartStr}
+            vols={weekVols}
+            locale={locale}
+            todayMonday={getMondayOfWeek(todayStr)}
+            emptyActionLabel={t('createFirst')}
+            emptyActionHref={`/${locale}/vols/create`}
+          />
         </div>
       </div>
     )

--- a/components/week-grid.tsx
+++ b/components/week-grid.tsx
@@ -2,8 +2,11 @@
 
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
-import { Badge } from '@/components/ui/badge'
+import { Plus } from 'lucide-react'
+import { Chip } from '@/components/cockpit/chip'
+import { MonoValue } from '@/components/cockpit/mono-value'
 import { EmptyState } from '@/components/empty-state'
+import { cn } from '@/lib/utils'
 
 export type VolSummary = {
   id: string
@@ -25,15 +28,18 @@ type WeekGridProps = {
   emptyActionHref?: string
 }
 
-const STATUT_BORDER: Record<string, string> = {
-  PLANIFIE: 'border-l-4 border-l-primary',
-  CONFIRME: 'border-l-4 border-l-success',
-  EN_VOL: 'border-l-4 border-l-info',
-  TERMINE: 'border-l-4 border-l-muted-foreground',
-  ANNULE: 'border-l-4 border-l-destructive',
+// Colored left border on vol cards, by lifecycle status
+const STATUT_BAR: Record<string, string> = {
+  PLANIFIE: 'border-l-sky-400',
+  CONFIRME: 'border-l-[color:var(--success)]',
+  EN_VOL: 'border-l-[color:var(--info)]',
+  TERMINE: 'border-l-sky-300',
+  ARCHIVE: 'border-l-sky-300',
+  ANNULE: 'border-l-[color:var(--destructive)]',
 }
 
-const DAY_SHORT = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim']
+const DAY_SHORT_FR = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim']
+const DAY_SHORT_EN = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 function addDays(dateStr: string, days: number): string {
   const d = new Date(dateStr + 'T12:00:00Z')
@@ -42,7 +48,6 @@ function addDays(dateStr: string, days: number): string {
 }
 
 function formatShortDate(dateStr: string): string {
-  // dateStr is YYYY-MM-DD
   const parts = dateStr.split('-')
   const month = parts[1] ?? '01'
   const day = parts[2] ?? '01'
@@ -53,51 +58,58 @@ function getMondayOffset(current: string, delta: number): string {
   return addDays(current, delta * 7)
 }
 
-type VolCardProps = {
-  vol: VolSummary
-  locale: string
+function capacityTone(count: number, max: number): Parameters<typeof Chip>[0]['tone'] {
+  if (max === 0) return 'neutral'
+  if (count > max) return 'danger'
+  if (count / max >= 0.8) return 'warn'
+  if (count / max >= 0.5) return 'info'
+  return 'neutral'
 }
 
-function VolCard({ vol, locale }: VolCardProps) {
-  const borderClass = STATUT_BORDER[vol.statut] ?? 'border-l-4 border-l-border'
+function VolCard({ vol, locale }: { vol: VolSummary; locale: string }) {
+  const barClass = STATUT_BAR[vol.statut] ?? 'border-l-sky-200'
   return (
-    <Link href={`/${locale}/vols/${vol.id}`} className="block">
-      <div
-        className={`bg-card rounded p-2 text-xs shadow-sm hover:shadow-md transition-shadow cursor-pointer ${borderClass}`}
-      >
-        <div className="font-semibold text-foreground truncate">{vol.ballonNom}</div>
-        <div className="text-muted-foreground mt-0.5">{vol.piloteInitiales}</div>
-        <div className="mt-1">
-          <Badge variant="outline" className="text-xs px-1 py-0">
-            {vol.passagerCount}/{vol.nbPassagerMax}
-          </Badge>
-        </div>
+    <Link
+      href={`/${locale}/vols/${vol.id}`}
+      className={cn(
+        'block rounded border border-sky-100 border-l-[3px] bg-card px-2 py-1.5 text-[11px] shadow-[var(--sh-1)] transition-shadow hover:shadow-[var(--sh-2)]',
+        barClass,
+      )}
+    >
+      <div className="truncate font-medium leading-tight text-sky-900">{vol.ballonNom}</div>
+      <div className="mono flex items-center justify-between text-[10px] text-sky-500">
+        <span>{vol.piloteInitiales}</span>
+        <Chip tone={capacityTone(vol.passagerCount, vol.nbPassagerMax)} size="sm">
+          <MonoValue value={`${vol.passagerCount}/${vol.nbPassagerMax}`} size={10} />
+        </Chip>
       </div>
     </Link>
   )
 }
 
-type CellProps = {
+function Cell({
+  date,
+  creneau,
+  vols,
+  locale,
+}: {
   date: string
   creneau: 'MATIN' | 'SOIR'
   vols: VolSummary[]
   locale: string
-}
-
-function Cell({ date, creneau, vols, locale }: CellProps) {
+}) {
   const cellVols = vols.filter((v) => v.date === date && v.creneau === creneau)
-
   return (
-    <div className="border border-border min-h-[80px] p-1 bg-muted/40 space-y-1">
+    <div className="flex min-h-[72px] flex-col gap-1 border-b border-r border-sky-100 bg-sky-0/60 p-1.5">
       {cellVols.map((vol) => (
         <VolCard key={vol.id} vol={vol} locale={locale} />
       ))}
       <Link
         href={`/${locale}/vols/create?date=${date}&creneau=${creneau}`}
-        className="flex items-center justify-center w-full h-6 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted rounded text-sm transition-colors"
-        title="Nouveau vol"
+        className="flex h-6 w-full items-center justify-center rounded text-sky-300 transition-colors hover:bg-sky-100 hover:text-sky-500"
+        aria-label="Nouveau vol"
       >
-        +
+        <Plus className="h-3.5 w-3.5" aria-hidden />
       </Link>
     </div>
   )
@@ -112,58 +124,65 @@ export function WeekGrid({
   emptyActionHref,
 }: WeekGridProps) {
   const t = useTranslations('vols')
-
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i))
   const prevWeek = getMondayOffset(weekStart, -1)
   const nextWeek = getMondayOffset(weekStart, 1)
+  const DAY_SHORT = locale === 'fr' ? DAY_SHORT_FR : DAY_SHORT_EN
 
   const navClass =
-    'px-3 py-1.5 text-sm border border-border rounded hover:bg-muted transition-colors'
+    'mono cap inline-flex items-center rounded-md border border-sky-200 bg-card px-3 py-1.5 text-[11px] text-sky-700 transition-colors hover:border-dusk-300 hover:text-dusk-700'
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {/* Week navigation */}
       <div className="flex items-center gap-2">
-        <Link href={`/${locale}/vols?week=${prevWeek}`} className={navClass}>
+        <Link
+          href={`/${locale}/vols?week=${prevWeek}`}
+          className={navClass}
+          aria-label="Previous week"
+        >
           &larr;
         </Link>
-        <Link href={`/${locale}/vols?week=${todayMonday}`} className={`${navClass} font-medium`}>
+        <Link href={`/${locale}/vols?week=${todayMonday}`} className={cn(navClass, 'font-medium')}>
           {t('today')}
         </Link>
-        <Link href={`/${locale}/vols?week=${nextWeek}`} className={navClass}>
+        <Link href={`/${locale}/vols?week=${nextWeek}`} className={navClass} aria-label="Next week">
           &rarr;
         </Link>
-        <span className="text-sm text-muted-foreground ml-2">
+        <span className="mono ml-2 text-[11px] text-sky-500">
           {t('week')} {formatShortDate(days[0] ?? weekStart)} &ndash;{' '}
           {formatShortDate(days[6] ?? weekStart)}
         </span>
       </div>
 
       {/* Grid */}
-      <div className="overflow-x-auto">
-        <div className="grid grid-cols-[80px_repeat(7,1fr)] min-w-[640px]">
+      <div className="overflow-x-auto rounded-lg border border-sky-100 bg-card shadow-[var(--sh-1)]">
+        <div className="grid min-w-[640px] grid-cols-[64px_repeat(7,1fr)]">
           {/* Header row */}
-          <div className="border border-border bg-card p-2" />
+          <div className="border-b border-r border-sky-100 bg-sky-50" />
           {days.map((day, i) => (
-            <div key={day} className="border border-border bg-card p-2 text-center">
-              <div className="text-xs font-semibold text-foreground">{DAY_SHORT[i]}</div>
-              <div className="text-xs text-muted-foreground">{formatShortDate(day)}</div>
+            <div
+              key={day}
+              className="flex flex-col items-center gap-0.5 border-b border-r border-sky-100 bg-sky-50 px-2 py-2 last:border-r-0"
+            >
+              <div className="mono cap text-[10px] text-sky-500">{DAY_SHORT[i]}</div>
+              <div className="mono text-[12px] font-medium text-sky-900">
+                {formatShortDate(day)}
+              </div>
             </div>
           ))}
 
           {/* MATIN row */}
-          <div className="border border-border bg-card p-2 flex items-center justify-center">
-            <span className="text-xs font-medium text-muted-foreground writing-mode-vertical rotate-0">
-              {t('creneau.MATIN')}
-            </span>
+          <div className="flex items-center justify-center border-b border-r border-sky-100 bg-sky-50 px-2 py-3">
+            <span className="mono cap text-[10px] text-sky-700">{t('creneau.MATIN')}</span>
           </div>
           {days.map((day) => (
             <Cell key={`matin-${day}`} date={day} creneau="MATIN" vols={vols} locale={locale} />
           ))}
 
           {/* SOIR row */}
-          <div className="border border-border bg-card p-2 flex items-center justify-center">
-            <span className="text-xs font-medium text-muted-foreground">{t('creneau.SOIR')}</span>
+          <div className="flex items-center justify-center border-r border-sky-100 bg-sky-50 px-2 py-3">
+            <span className="mono cap text-[10px] text-sky-700">{t('creneau.SOIR')}</span>
           </div>
           {days.map((day) => (
             <Cell key={`soir-${day}`} date={day} creneau="SOIR" vols={vols} locale={locale} />

--- a/messages/en.json
+++ b/messages/en.json
@@ -464,6 +464,8 @@
   },
   "vols": {
     "title": "Flight planning",
+    "kicker": "Weekly view",
+    "detailKicker": "Flight brief",
     "new": "New flight",
     "backToList": "Back to planning",
     "detail": "Flight detail",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -464,6 +464,8 @@
   },
   "vols": {
     "title": "Planning des vols",
+    "kicker": "Vue hebdo",
+    "detailKicker": "Dossier de vol",
     "new": "Nouveau vol",
     "backToList": "Retour au planning",
     "detail": "Détail du vol",


### PR DESCRIPTION
## Summary

**Phase 4** du chantier refonte UI — dernière phase visuelle. Aligne le planning hebdo et le détail vol sur la direction cockpit installée en phases 1-3.

## Changements

### `components/week-grid.tsx`
- Carte bordée sky-100 + shadow-1 autour de la grille, cellules sur fond `sky-0/60`
- En-têtes jours en mono caps (`LUN MAR MER…`) + date courte mono
- VolCard : border-left 3px colorée par statut (sky-400 / success / info / sky-300 / destructive), Archivo ballon name, mono pilot initials, **Chip capacité tone-aware** (neutral → info → warn → danger selon remplissage)
- "+" créneau vide → icône Lucide `Plus` sky-300 avec hover dusk
- Pills de navigation semaine mono caps avec border dusk-300 au hover
- Support locale FR/EN pour les en-têtes jours

### `app/[locale]/(app)/vols/page.tsx`
- Header : kicker mono `VUE HEBDO` + Archivo 3xl + bouton droite (même pattern que dashboard Phase 3)
- Drop du `Card` wrapper autour de `WeekGrid` — la grille gère son propre frame

### `app/[locale]/(app)/vols/[id]/page.tsx`
- Header totalement refait : **bandeau cockpit navy** (`bg-sky-900`, text `sky-100`), kicker `DOSSIER DE VOL`, titre Archivo date + créneau en dusk-200, ligne mono méta (immat · ballon · pilote)
- "Retour au planning" en mono dusk
- Statut badge + boutons edit/organiser restylés pour surface sombre (border sky-600, bg sky-800)
- Autres sections (Card info, Passagers, Météo, Devis) inchangées — elles adoptent les nouveaux tokens automatiquement

## i18n

Ajoutées sous `vols.*` (fr/en) :
- `vols.kicker` → `"Vue hebdo"` / `"Weekly view"`
- `vols.detailKicker` → `"Dossier de vol"` / `"Flight brief"`

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : grille hebdo desktop (avec vols et sans vols), navigation semaine, clic créneau vide, détail vol (bandeau cockpit, restylé pour chaque statut)

## Ce qui reste ouvert

- Les 4 phases du design bundle sont livrées. Les 3 blocs dashboard reportés de Phase 3 (GO/HOLD/NO-GO timeline, flotte, 7 prochains vols) peuvent attendre un ticket dédié si besoin — ils n'étaient pas dans les 4 écrans du design bundle.

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32