### PR TITLE
refonte(phase 5): dashboard deferred blocks — GO/HOLD/NOGO + fleet + upcoming

### DIFF
--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -14,9 +14,26 @@ import { AlertsBanner } from '@/components/alerts-banner'
 import { FlightCard, type FlightCardData } from '@/components/flight-card'
 import { KpiRow, KpiTile } from '@/components/cockpit/kpi-tile'
 import { WindArrow } from '@/components/cockpit/wind-arrow'
+import { GoNogoWindow } from '@/components/cockpit/go-nogo-window'
+import { FleetRow, type FleetBallon } from '@/components/cockpit/fleet-row'
+import {
+  UpcomingFlightsTable,
+  type UpcomingFlight,
+} from '@/components/cockpit/upcoming-flights-table'
 import { Button } from '@/components/ui/button'
 import type { Prisma } from '@prisma/client'
 import type { WeatherForecast, WeatherSummary } from '@/lib/weather/types'
+
+function camoStatusOf(
+  camoExpiryDate: Date | null | undefined,
+  now: Date,
+): FleetBallon['camoStatus'] {
+  if (!camoExpiryDate) return 'UNKNOWN'
+  const days = Math.floor((camoExpiryDate.getTime() - now.getTime()) / 86_400_000)
+  if (days < 0) return 'EXPIRED'
+  if (days <= 30) return 'SOON'
+  return 'OK'
+}
 
 type Props = {
   params: Promise<{ locale: string }>
@@ -138,6 +155,44 @@ export default async function HomePage({ params }: Props) {
       }
     }
 
+    // 4a. Fetch upcoming vols (excluding today) for fleet next-flight and upcoming table
+    const UPCOMING_LOOKAHEAD_DAYS = 60
+    const upcomingLookaheadEnd = new Date(today)
+    upcomingLookaheadEnd.setDate(upcomingLookaheadEnd.getDate() + UPCOMING_LOOKAHEAD_DAYS)
+
+    const upcomingWhere = buildVolWhereForRole(
+      {
+        date: { gt: today, lte: upcomingLookaheadEnd },
+        statut: { not: 'ANNULE' as const },
+      },
+      ctx.role,
+      ctx.userId,
+    )
+
+    const upcomingVolsRaw = await db.vol.findMany({
+      where: upcomingWhere,
+      include: {
+        ballon: { select: { id: true, nom: true, immatriculation: true, nbPassagerMax: true } },
+        pilote: { select: { prenom: true, nom: true } },
+        _count: { select: { passagers: true } },
+      },
+      orderBy: [{ date: 'asc' }, { creneau: 'asc' }],
+      take: 30,
+    })
+
+    // 4b. All active ballons for Fleet row (independent of today's vols)
+    const fleetBallons = await db.ballon.findMany({
+      where: { actif: true },
+      select: {
+        id: true,
+        nom: true,
+        immatriculation: true,
+        camoExpiryDate: true,
+        actif: true,
+      },
+      orderBy: { immatriculation: 'asc' },
+    })
+
     // 4. Build regulatory alerts filtered to today's entities
     const todayBallonIds = [...new Set(vols.map((v) => v.ballonId))]
     const todayPiloteIds = [...new Set(vols.map((v) => v.piloteId))]
@@ -194,6 +249,42 @@ export default async function HomePage({ params }: Props) {
         meteoAlert: vol.meteoAlert,
       }
     })
+
+    // 5b. Derive Fleet row: next flight per active ballon
+    const nextFlightByBallon = new Map<string, { date: string; creneau: 'MATIN' | 'SOIR' }>()
+    for (const uv of upcomingVolsRaw) {
+      if (!nextFlightByBallon.has(uv.ballon.id)) {
+        nextFlightByBallon.set(uv.ballon.id, {
+          date: uv.date.toISOString().slice(0, 10),
+          creneau: uv.creneau as 'MATIN' | 'SOIR',
+        })
+      }
+    }
+    const fleetRows: FleetBallon[] = fleetBallons.map((b) => ({
+      id: b.id,
+      nom: b.nom,
+      immat: b.immatriculation,
+      actif: b.actif,
+      camoStatus: camoStatusOf(b.camoExpiryDate, today),
+      nextFlight: nextFlightByBallon.get(b.id) ?? null,
+    }))
+
+    // 5c. Build 7 next upcoming flights
+    const upcomingFlights: UpcomingFlight[] = upcomingVolsRaw.slice(0, 7).map((uv) => ({
+      id: uv.id,
+      date: uv.date.toISOString().slice(0, 10),
+      creneau: uv.creneau as 'MATIN' | 'SOIR',
+      statut: uv.statut,
+      ballonImmat: uv.ballon.immatriculation,
+      ballonNom: uv.ballon.nom,
+      piloteNom: `${uv.pilote.prenom} ${uv.pilote.nom}`,
+      passagerCount: uv._count.passagers,
+      passagerMax: uv.ballon.nbPassagerMax,
+    }))
+
+    // 5d. Weather hours for GO/HOLD/NOGO window
+    const matinHours = forecast ? extractCreneauHours(forecast, 'MATIN') : []
+    const soirHours = forecast ? extractCreneauHours(forecast, 'SOIR') : []
 
     // 6. Derive cockpit KPIs from today's data
     const nextFlight = cards[0] ?? null
@@ -258,6 +349,10 @@ export default async function HomePage({ params }: Props) {
 
         {criticalAlerts.length > 0 && <AlertsBanner alerts={criticalAlerts} />}
 
+        {forecast && (
+          <GoNogoWindow matinHours={matinHours} soirHours={soirHours} seuilVent={seuilVent} />
+        )}
+
         {vols.length === 0 ? (
           <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-sky-200 bg-card py-16 text-center">
             <Plane className="mb-4 h-12 w-12 text-sky-300" aria-hidden />
@@ -273,6 +368,10 @@ export default async function HomePage({ params }: Props) {
             ))}
           </div>
         )}
+
+        <FleetRow ballons={fleetRows} locale={locale} />
+
+        <UpcomingFlightsTable flights={upcomingFlights} locale={locale} />
       </div>
     )
   })

--- a/components/cockpit/fleet-row.tsx
+++ b/components/cockpit/fleet-row.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import Link from 'next/link'
+import { useTranslations } from 'next-intl'
+import { Chip } from '@/components/cockpit/chip'
+import { MonoValue } from '@/components/cockpit/mono-value'
+
+export type FleetBallon = {
+  id: string
+  nom: string
+  immat: string
+  actif: boolean
+  camoStatus: 'OK' | 'SOON' | 'EXPIRED' | 'UNKNOWN'
+  nextFlight: { date: string; creneau: 'MATIN' | 'SOIR' } | null
+}
+
+type Props = {
+  ballons: FleetBallon[]
+  locale: string
+}
+
+const CAMO_TONE: Record<FleetBallon['camoStatus'], Parameters<typeof Chip>[0]['tone']> = {
+  OK: 'ok',
+  SOON: 'warn',
+  EXPIRED: 'danger',
+  UNKNOWN: 'neutral',
+}
+
+function formatDateShort(dateStr: string, locale: string): string {
+  const d = new Date(dateStr + 'T12:00:00Z')
+  return d.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-US', {
+    day: '2-digit',
+    month: 'short',
+  })
+}
+
+/**
+ * Flotte — ligne de cartes compactes: immat mono + nom ballon + statut CAMO
+ * + prochain vol (date · créneau). Clic → détail ballon.
+ */
+export function FleetRow({ ballons, locale }: Props) {
+  const t = useTranslations('dashboard')
+  if (ballons.length === 0) return null
+  return (
+    <section className="space-y-2">
+      <h2 className="font-display text-sm font-semibold text-sky-900">{t('fleet.title')}</h2>
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {ballons.map((b) => (
+          <Link
+            key={b.id}
+            href={`/${locale}/ballons/${b.id}`}
+            className="flex items-center gap-3 rounded-lg border border-sky-100 bg-card p-3 shadow-[var(--sh-1)] transition-shadow hover:shadow-[var(--sh-2)]"
+          >
+            <div className="flex-1 min-w-0 space-y-1">
+              <div className="flex items-center gap-2 min-w-0">
+                <MonoValue value={b.immat} size={12} />
+                <span className="truncate text-[13px] font-medium text-sky-900">{b.nom}</span>
+              </div>
+              <div className="flex items-center gap-1.5 text-[11px] text-sky-500">
+                <Chip tone={CAMO_TONE[b.camoStatus]} size="sm">
+                  {t(`fleet.camo.${b.camoStatus}`)}
+                </Chip>
+                {b.nextFlight ? (
+                  <span className="mono">
+                    {formatDateShort(b.nextFlight.date, locale)} ·{' '}
+                    {t(`fleet.creneau.${b.nextFlight.creneau}`)}
+                  </span>
+                ) : (
+                  <span className="italic text-sky-400">{t('fleet.noNextFlight')}</span>
+                )}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/cockpit/go-nogo-window.tsx
+++ b/components/cockpit/go-nogo-window.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { cn } from '@/lib/utils'
+import type { HourlyWeather } from '@/lib/weather/types'
+
+type WindowLevel = 'GO' | 'HOLD' | 'NOGO'
+
+const LEVEL_STYLES: Record<WindowLevel, string> = {
+  GO: 'bg-emerald-50 text-[color:var(--success)]',
+  HOLD: 'bg-dusk-50 text-dusk-700',
+  NOGO: 'bg-red-50 text-[color:var(--destructive)]',
+}
+
+function hourLevel(windKt: number, seuilVent: number): WindowLevel {
+  if (windKt >= seuilVent) return 'NOGO'
+  if (windKt >= seuilVent * 0.75) return 'HOLD'
+  return 'GO'
+}
+
+function maxWindOfHour(h: HourlyWeather): number {
+  return Math.max(h.wind10m.speed, h.wind80m.speed, h.wind120m.speed, h.wind180m.speed)
+}
+
+type CreneauTimelineProps = {
+  label: string
+  hours: HourlyWeather[]
+  seuilVent: number
+}
+
+function CreneauTimeline({ label, hours, seuilVent }: CreneauTimelineProps) {
+  const t = useTranslations('dashboard')
+  if (hours.length === 0) {
+    return (
+      <div className="flex items-center gap-3 py-1.5 text-[11px]">
+        <span className="mono cap w-14 shrink-0 text-sky-500">{label}</span>
+        <span className="italic text-sky-400">{t('window.noData')}</span>
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center gap-3">
+      <span className="mono cap w-14 shrink-0 text-sky-500">{label}</span>
+      <div className="flex flex-1 gap-0.5">
+        {hours.map((h) => {
+          const wind = Math.round(maxWindOfHour(h))
+          const level = hourLevel(wind, seuilVent)
+          return (
+            <div
+              key={h.time}
+              title={`${h.time} · ${wind}kt · ${t(`window.level.${level}`)}`}
+              className={cn(
+                'flex flex-1 flex-col items-center justify-center rounded px-1 py-1.5',
+                LEVEL_STYLES[level],
+              )}
+            >
+              <span className="mono text-[10px] font-semibold leading-tight">
+                {h.time.slice(0, 2)}h
+              </span>
+              <span className="mono text-[10px] leading-tight opacity-80">{wind}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+type GoNogoWindowProps = {
+  matinHours: HourlyWeather[]
+  soirHours: HourlyWeather[]
+  seuilVent: number
+}
+
+/**
+ * Fenêtre GO/HOLD/NO-GO — 2 timelines horaires (matin + soir) avec chaque
+ * case colorée selon la vitesse du vent par rapport au seuil exploitant.
+ * GO      si vent < 75% seuil
+ * HOLD    si 75% seuil ≤ vent < seuil
+ * NO-GO   si vent ≥ seuil
+ */
+export function GoNogoWindow({ matinHours, soirHours, seuilVent }: GoNogoWindowProps) {
+  const t = useTranslations('dashboard')
+  return (
+    <section className="space-y-3 rounded-lg border border-sky-100 bg-card p-4 shadow-[var(--sh-1)]">
+      <div className="flex items-center justify-between">
+        <h2 className="font-display text-sm font-semibold text-sky-900">{t('window.title')}</h2>
+        <div className="mono flex items-center gap-3 text-[10px] text-sky-500">
+          <Legend color="bg-emerald-50" label={t('window.level.GO')} />
+          <Legend color="bg-dusk-50" label={t('window.level.HOLD')} />
+          <Legend color="bg-red-50" label={t('window.level.NOGO')} />
+          <span className="cap opacity-70">{t('window.threshold', { value: seuilVent })}</span>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <CreneauTimeline label={t('window.matin')} hours={matinHours} seuilVent={seuilVent} />
+        <CreneauTimeline label={t('window.soir')} hours={soirHours} seuilVent={seuilVent} />
+      </div>
+    </section>
+  )
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className={cn('h-2 w-2 rounded-sm border border-sky-200', color)} aria-hidden />
+      <span>{label}</span>
+    </span>
+  )
+}

--- a/components/cockpit/upcoming-flights-table.tsx
+++ b/components/cockpit/upcoming-flights-table.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import Link from 'next/link'
+import { useTranslations } from 'next-intl'
+import { Chip } from '@/components/cockpit/chip'
+import { MonoValue } from '@/components/cockpit/mono-value'
+
+export type UpcomingFlight = {
+  id: string
+  date: string // YYYY-MM-DD
+  creneau: 'MATIN' | 'SOIR'
+  statut: string
+  ballonImmat: string
+  ballonNom: string
+  piloteNom: string
+  passagerCount: number
+  passagerMax: number
+}
+
+const STATUT_TONE: Record<string, Parameters<typeof Chip>[0]['tone']> = {
+  PLANIFIE: 'neutral',
+  CONFIRME: 'info',
+  TERMINE: 'ok',
+  ARCHIVE: 'neutral',
+  ANNULE: 'danger',
+}
+
+function formatDate(dateStr: string, locale: string): string {
+  const d = new Date(dateStr + 'T12:00:00Z')
+  return d.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-US', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+  })
+}
+
+type Props = {
+  flights: UpcomingFlight[]
+  locale: string
+}
+
+/**
+ * Mini-table des 7 prochains vols planifiés — densité cockpit, clic row → détail.
+ */
+export function UpcomingFlightsTable({ flights, locale }: Props) {
+  const t = useTranslations('dashboard')
+  const tv = useTranslations('vols')
+  if (flights.length === 0) return null
+  return (
+    <section className="space-y-2">
+      <h2 className="font-display text-sm font-semibold text-sky-900">
+        {t('upcoming.title', { count: flights.length })}
+      </h2>
+      <div className="overflow-hidden rounded-lg border border-sky-100 bg-card shadow-[var(--sh-1)]">
+        <table className="w-full text-left text-[12px]">
+          <thead className="bg-sky-50">
+            <tr className="mono cap text-[10px] text-sky-500">
+              <th className="px-3 py-2 font-medium">{t('upcoming.col.date')}</th>
+              <th className="px-3 py-2 font-medium">{t('upcoming.col.creneau')}</th>
+              <th className="px-3 py-2 font-medium">{t('upcoming.col.ballon')}</th>
+              <th className="px-3 py-2 font-medium">{t('upcoming.col.pilote')}</th>
+              <th className="px-3 py-2 font-medium">{t('upcoming.col.pax')}</th>
+              <th className="px-3 py-2 font-medium">{t('upcoming.col.statut')}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-sky-100">
+            {flights.map((f) => (
+              <tr key={f.id} className="transition-colors hover:bg-sky-50">
+                <td className="px-3 py-2">
+                  <Link href={`/${locale}/vols/${f.id}`} className="block text-sky-900">
+                    {formatDate(f.date, locale)}
+                  </Link>
+                </td>
+                <td className="px-3 py-2">
+                  <Chip tone="dusk" size="sm">
+                    {tv(`creneau.${f.creneau}`)}
+                  </Chip>
+                </td>
+                <td className="px-3 py-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <MonoValue value={f.ballonImmat} size={11} tone="muted" />
+                    <span className="truncate text-sky-900">{f.ballonNom}</span>
+                  </div>
+                </td>
+                <td className="px-3 py-2 text-sky-700">{f.piloteNom}</td>
+                <td className="px-3 py-2">
+                  <MonoValue value={`${f.passagerCount}/${f.passagerMax}`} size={11} />
+                </td>
+                <td className="px-3 py-2">
+                  <Chip tone={STATUT_TONE[f.statut] ?? 'neutral'} size="sm">
+                    {tv(`statut.${f.statut}`)}
+                  </Chip>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -719,7 +719,44 @@
     "meteoAlert": "Wind forecast above threshold",
     "meteoAlertAction": "Cancel this flight?",
     "cancelMeteo": "Cancel (weather)",
-    "cancelMeteoConfirm": "Cancel this flight due to weather? Passengers will be unassigned and contacts notified by email."
+    "cancelMeteoConfirm": "Cancel this flight due to weather? Passengers will be unassigned and contacts notified by email.",
+    "window": {
+      "title": "Today's flight window",
+      "matin": "Morning",
+      "soir": "Evening",
+      "threshold": "Threshold {value} kt",
+      "noData": "No weather data",
+      "level": {
+        "GO": "GO",
+        "HOLD": "HOLD",
+        "NOGO": "NO-GO"
+      }
+    },
+    "fleet": {
+      "title": "Fleet",
+      "noNextFlight": "No upcoming flight",
+      "camo": {
+        "OK": "CAMO OK",
+        "SOON": "CAMO 30d",
+        "EXPIRED": "CAMO expired",
+        "UNKNOWN": "CAMO ?"
+      },
+      "creneau": {
+        "MATIN": "morning",
+        "SOIR": "evening"
+      }
+    },
+    "upcoming": {
+      "title": "{count, plural, one {Next flight} other {# upcoming flights}}",
+      "col": {
+        "date": "Date",
+        "creneau": "Slot",
+        "ballon": "Balloon",
+        "pilote": "Pilot",
+        "pax": "PAX",
+        "statut": "Status"
+      }
+    }
   },
   "cancellation": {
     "emailSubjectPayeur": "Flight cancelled — {date}",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -719,6 +719,43 @@
       "paxCovered": "{booked}/{seats}",
       "flights": "VOLS",
       "flightsSub": "Aujourd'hui"
+    },
+    "window": {
+      "title": "Fenêtre météo du jour",
+      "matin": "Matin",
+      "soir": "Soir",
+      "threshold": "Seuil {value} kt",
+      "noData": "Pas de données météo",
+      "level": {
+        "GO": "GO",
+        "HOLD": "HOLD",
+        "NOGO": "NO-GO"
+      }
+    },
+    "fleet": {
+      "title": "Flotte",
+      "noNextFlight": "Aucun vol programmé",
+      "camo": {
+        "OK": "CAMO OK",
+        "SOON": "CAMO 30j",
+        "EXPIRED": "CAMO expiré",
+        "UNKNOWN": "CAMO ?"
+      },
+      "creneau": {
+        "MATIN": "matin",
+        "SOIR": "soir"
+      }
+    },
+    "upcoming": {
+      "title": "{count, plural, one {Prochain vol} other {# prochains vols}}",
+      "col": {
+        "date": "Date",
+        "creneau": "Créneau",
+        "ballon": "Ballon",
+        "pilote": "Pilote",
+        "pax": "PAX",
+        "statut": "Statut"
+      }
     }
   },
   "cancellation": {


### PR DESCRIPTION
## Summary

**Phase 5** (complément de la Phase 3) — livre les 3 blocs dashboard reportés pour tenir le scope de la refonte initiale.

## Nouveaux blocs

### 1. `GoNogoWindow` (timeline météo horaire)
2 rails horizontaux (MATIN 05-10h / SOIR 17-22h) — chaque case = une heure, colorée **GO** / **HOLD** / **NO-GO** selon la vitesse du vent vs le seuil configuré sur l'exploitant.

- **GO** (emerald) : vent < 75% du seuil
- **HOLD** (dusk) : 75% ≤ vent < seuil
- **NO-GO** (red) : vent ≥ seuil

Label heure + vent en mono dans chaque case, légende + seuil affiché en haut à droite.

### 2. `FleetRow`
Grille responsive (1 → 4 colonnes) des ballons actifs : immat mono, nom ballon, chip CAMO (**OK** / **SOON** 30j / **EXPIRED** / **UNKNOWN** — calcul client à partir de `camoExpiryDate`), prochain vol `date · créneau`. Clic → `/ballons/[id]`.

### 3. `UpcomingFlightsTable`
Mini-table 6 colonnes (date / créneau chip / mono immat + ballon / pilote / mono PAX / statut chip) des 7 prochains vols (hors aujourd'hui), ligne cliquable → détail.

## Requêtes ajoutées au dashboard

- `upcomingVolsRaw` : jusqu'à 30 vols dans les 60 prochains jours, `statut ≠ ANNULE`, role-scoped — alimente **next-flight-per-ballon** + upcoming table
- `fleetBallons` : tous les ballons actifs (select minimal + `camoExpiryDate`)

Dérivation : `nextFlightByBallon` via Map en un passage, puis mapping vers `FleetBallon[]` avec `camoStatus` calculé.

## i18n (fr/en)

- `dashboard.window.{title,matin,soir,threshold,noData,level.{GO,HOLD,NOGO}}`
- `dashboard.fleet.{title,noNextFlight,camo.{OK,SOON,EXPIRED,UNKNOWN},creneau.{MATIN,SOIR}}`
- `dashboard.upcoming.{title,col.{date,creneau,ballon,pilote,pax,statut}}`

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : GO/HOLD/NOGO avec/sans forecast, FleetRow 0/1/N ballons, UpcomingFlightsTable 0 / 1 / 7 vols, CAMO OK / SOON / EXPIRED / UNKNOWN

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32