### PR TITLE
review pass: i18n gaps, a11y, mobile flight-card, contrast

### DIFF
--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -21,6 +21,7 @@ import {
   type UpcomingFlight,
 } from '@/components/cockpit/upcoming-flights-table'
 import { Button } from '@/components/ui/button'
+import { formatDateLong } from '@/lib/format'
 import type { Prisma } from '@prisma/client'
 import type { WeatherForecast, WeatherSummary } from '@/lib/weather/types'
 
@@ -90,6 +91,7 @@ export default async function HomePage({ params }: Props) {
 
   return requireAuth(async () => {
     const t = await getTranslations('dashboard')
+    const tVols = await getTranslations('vols')
     const ctx = getContext()
 
     const today = new Date()
@@ -135,10 +137,7 @@ export default async function HomePage({ params }: Props) {
 
     const seuilVent = exploitant.meteoSeuilVent ?? 15
 
-    const CRENEAU_LABELS: Record<string, string> = {
-      MATIN: '05h — 10h',
-      SOIR: '17h — 22h',
-    }
+    const creneauRange = (creneau: 'MATIN' | 'SOIR') => tVols(`timeRange.${creneau}`)
 
     // Helper: get weather summary per créneau
     function getWeatherForCreneau(creneau: 'MATIN' | 'SOIR'): FlightCardData['weather'] {
@@ -151,7 +150,7 @@ export default async function HomePage({ params }: Props) {
         maxWindAltitude: summary.maxWindAltitude,
         avgTemperature: summary.avgTemperature,
         goNogo: levelToGoNogo(summary.level),
-        creneauRange: CRENEAU_LABELS[creneau] ?? '',
+        creneauRange: creneauRange(creneau),
       }
     }
 
@@ -295,12 +294,7 @@ export default async function HomePage({ params }: Props) {
     const paxBooked = cards.reduce((sum, c) => sum + c.passagerCount, 0)
     const paxSeats = cards.reduce((sum, c) => sum + c.passagerMax, 0)
 
-    const dateLabel = today.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-US', {
-      weekday: 'long',
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-    })
+    const dateLabel = formatDateLong(today, locale)
 
     return (
       <div className="space-y-6">
@@ -323,7 +317,7 @@ export default async function HomePage({ params }: Props) {
         <KpiRow>
           <KpiTile
             label={t('kpi.nextFlight')}
-            value={nextFlight ? CRENEAU_LABELS[nextFlight.creneau] : t('kpi.nextFlightEmpty')}
+            value={nextFlight ? creneauRange(nextFlight.creneau) : t('kpi.nextFlightEmpty')}
             sub={nextFlight ? `${nextFlight.ballonImmat} · ${nextFlight.ballonNom}` : null}
             tone={nextFlight ? 'dusk' : 'default'}
           />

--- a/app/[locale]/(app)/vols/[id]/page.tsx
+++ b/app/[locale]/(app)/vols/[id]/page.tsx
@@ -22,7 +22,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
-import { formatDateFr } from '@/lib/format'
+import { formatDateFr, formatDateTimeShort } from '@/lib/format'
 import { VolActions } from './vol-actions'
 import { MeteoAlertBanner } from '@/components/meteo-alert-banner'
 import { WeatherTable } from '@/components/weather-table'
@@ -60,6 +60,7 @@ export default async function VolDetailPage({ params }: Props) {
   return requireAuth(async () => {
     const t = await getTranslations('vols')
     const tPassagers = await getTranslations('passagers')
+    const tVolPassagers = await getTranslations('vols.passagers')
     const ctx = getContext()
     const canEdit = ctx.role === 'ADMIN_CALPAX' || ctx.role === 'GERANT'
 
@@ -266,7 +267,9 @@ export default async function VolDetailPage({ params }: Props) {
         {/* Passagers card */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Passagers ({vol.passagers.length})</CardTitle>
+            <CardTitle className="text-base">
+              {tVolPassagers('title', { count: vol.passagers.length })}
+            </CardTitle>
           </CardHeader>
           <CardContent>
             {vol.passagers.length === 0 ? (
@@ -283,7 +286,7 @@ export default async function VolDetailPage({ params }: Props) {
                       <TableHead className={labelClassName}>{tPassagers('fields.age')}</TableHead>
                       <TableHead className={labelClassName}>{tPassagers('fields.poids')}</TableHead>
                       <TableHead className={labelClassName}>{tPassagers('fields.pmr')}</TableHead>
-                      <TableHead className={labelClassName}>Billet</TableHead>
+                      <TableHead className={labelClassName}>{tVolPassagers('billet')}</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -295,7 +298,9 @@ export default async function VolDetailPage({ params }: Props) {
                           <TableCell>{p.nom}</TableCell>
                           <TableCell>{p.age ?? '—'}</TableCell>
                           <TableCell>{poids !== null ? `${poids} kg` : '—'}</TableCell>
-                          <TableCell>{p.pmr ? 'Oui' : 'Non'}</TableCell>
+                          <TableCell>
+                            {p.pmr ? tVolPassagers('pmrYes') : tVolPassagers('pmrNo')}
+                          </TableCell>
                           <TableCell className="text-muted-foreground text-xs">
                             {p.billet.reference}
                           </TableCell>
@@ -334,13 +339,8 @@ export default async function VolDetailPage({ params }: Props) {
             </CardTitle>
             {weatherFetchedAt && (
               <p className="text-xs text-muted-foreground">
-                Source : Open-Meteo (best match) — maj{' '}
-                {weatherFetchedAt.toLocaleString('fr-FR', {
-                  day: '2-digit',
-                  month: '2-digit',
-                  year: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
+                {tMeteo('sourceFetchedAt', {
+                  date: formatDateTimeShort(weatherFetchedAt, locale),
                 })}
               </p>
             )}
@@ -363,15 +363,12 @@ export default async function VolDetailPage({ params }: Props) {
           </CardHeader>
           <CardContent>
             {devis === null ? (
-              <p className="text-muted-foreground text-sm">
-                Donnees insuffisantes pour calculer le devis de masse (poids pilote ou quantite gaz
-                manquants).
-              </p>
+              <p className="text-muted-foreground text-sm">{t('devis.insufficientData')}</p>
             ) : (
               <div className="space-y-4">
                 <p className="text-xs text-muted-foreground">
                   {t('devis.temperature')} : {devisTemperature} C
-                  {weatherSummary ? '' : ' (temperature par defaut)'}
+                  {weatherSummary ? '' : ` ${t('devis.temperatureDefault')}`}
                 </p>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 text-sm">
                   <div>

--- a/components/flight-card.tsx
+++ b/components/flight-card.tsx
@@ -107,7 +107,7 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
       {flight.meteoAlert && (
         <div
           role="status"
-          className="-mx-4 -mt-4 flex items-center gap-2 border-b border-dusk-200 bg-dusk-50 px-4 py-2 text-xs font-medium text-dusk-700"
+          className="-mx-4 -mt-4 flex items-center gap-2 border-b border-dusk-300 bg-dusk-100 px-4 py-2 text-xs font-medium text-dusk-800"
         >
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden />
           <span>{t('meteoAlert')}</span>
@@ -128,8 +128,8 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
         </Chip>
       </div>
 
-      {/* Meta grid 2x2 */}
-      <div className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+      {/* Meta grid: 1 col on narrow phones, 2 cols from ~380px up */}
+      <div className="grid grid-cols-1 gap-x-4 gap-y-3 text-sm min-[380px]:grid-cols-2">
         <MetaField label={tv('fields.pilote')} value={flight.piloteNom} />
         <MetaField label={tv('fields.equipier')} value={flight.equipierNom ?? '—'} />
         <MetaField label={tv('fields.lieuDecollage')} value={flight.siteDeco ?? '—'} />

--- a/components/week-grid.tsx
+++ b/components/week-grid.tsx
@@ -92,11 +92,13 @@ function Cell({
   creneau,
   vols,
   locale,
+  ariaNewFlight,
 }: {
   date: string
   creneau: 'MATIN' | 'SOIR'
   vols: VolSummary[]
   locale: string
+  ariaNewFlight: string
 }) {
   const cellVols = vols.filter((v) => v.date === date && v.creneau === creneau)
   return (
@@ -107,7 +109,7 @@ function Cell({
       <Link
         href={`/${locale}/vols/create?date=${date}&creneau=${creneau}`}
         className="flex h-6 w-full items-center justify-center rounded text-sky-300 transition-colors hover:bg-sky-100 hover:text-sky-500"
-        aria-label="Nouveau vol"
+        aria-label={ariaNewFlight}
       >
         <Plus className="h-3.5 w-3.5" aria-hidden />
       </Link>
@@ -128,6 +130,9 @@ export function WeekGrid({
   const prevWeek = getMondayOffset(weekStart, -1)
   const nextWeek = getMondayOffset(weekStart, 1)
   const DAY_SHORT = locale === 'fr' ? DAY_SHORT_FR : DAY_SHORT_EN
+  const ariaNewFlight = t('nouveauVol')
+  const ariaPrevWeek = t('prevWeek')
+  const ariaNextWeek = t('nextWeek')
 
   const navClass =
     'mono cap inline-flex items-center rounded-md border border-sky-200 bg-card px-3 py-1.5 text-[11px] text-sky-700 transition-colors hover:border-dusk-300 hover:text-dusk-700'
@@ -139,15 +144,19 @@ export function WeekGrid({
         <Link
           href={`/${locale}/vols?week=${prevWeek}`}
           className={navClass}
-          aria-label="Previous week"
+          aria-label={ariaPrevWeek}
         >
-          &larr;
+          <span aria-hidden>&larr;</span>
         </Link>
         <Link href={`/${locale}/vols?week=${todayMonday}`} className={cn(navClass, 'font-medium')}>
           {t('today')}
         </Link>
-        <Link href={`/${locale}/vols?week=${nextWeek}`} className={navClass} aria-label="Next week">
-          &rarr;
+        <Link
+          href={`/${locale}/vols?week=${nextWeek}`}
+          className={navClass}
+          aria-label={ariaNextWeek}
+        >
+          <span aria-hidden>&rarr;</span>
         </Link>
         <span className="mono ml-2 text-[11px] text-sky-500">
           {t('week')} {formatShortDate(days[0] ?? weekStart)} &ndash;{' '}
@@ -177,7 +186,14 @@ export function WeekGrid({
             <span className="mono cap text-[10px] text-sky-700">{t('creneau.MATIN')}</span>
           </div>
           {days.map((day) => (
-            <Cell key={`matin-${day}`} date={day} creneau="MATIN" vols={vols} locale={locale} />
+            <Cell
+              key={`matin-${day}`}
+              date={day}
+              creneau="MATIN"
+              vols={vols}
+              locale={locale}
+              ariaNewFlight={ariaNewFlight}
+            />
           ))}
 
           {/* SOIR row */}
@@ -185,7 +201,14 @@ export function WeekGrid({
             <span className="mono cap text-[10px] text-sky-700">{t('creneau.SOIR')}</span>
           </div>
           {days.map((day) => (
-            <Cell key={`soir-${day}`} date={day} creneau="SOIR" vols={vols} locale={locale} />
+            <Cell
+              key={`soir-${day}`}
+              date={day}
+              creneau="SOIR"
+              vols={vols}
+              locale={locale}
+              ariaNewFlight={ariaNewFlight}
+            />
           ))}
         </div>
       </div>

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -5,3 +5,26 @@ export function formatDateFr(date: Date): string {
     year: 'numeric',
   })
 }
+
+function localeTag(locale: string): 'fr-FR' | 'en-US' {
+  return locale === 'fr' ? 'fr-FR' : 'en-US'
+}
+
+export function formatDateLong(date: Date, locale: string): string {
+  return date.toLocaleDateString(localeTag(locale), {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+export function formatDateTimeShort(date: Date, locale: string): string {
+  return date.toLocaleString(localeTag(locale), {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -258,6 +258,7 @@
     "maxWind": "Max wind",
     "avgTemp": "Avg OAT",
     "source": "Source: Open-Meteo.com",
+    "sourceFetchedAt": "Source: Open-Meteo (best match) — updated {date}",
     "fields": {
       "heure": "Hour",
       "vent10m": "Wind 10m",
@@ -508,6 +509,8 @@
     "devis": {
       "title": "Load sheet",
       "temperature": "Temperature (C)",
+      "temperatureDefault": "(default temperature)",
+      "insufficientData": "Insufficient data to compute the load sheet (missing pilot weight or gas quantity).",
       "poidsAVide": "Empty weight",
       "poidsGaz": "Gas loaded",
       "poidsPilote": "Pilot",
@@ -520,6 +523,19 @@
       "conforme": "COMPLIANT",
       "surcharge": "OVERLOADED"
     },
+    "passagers": {
+      "title": "Passengers ({count})",
+      "billet": "Ticket",
+      "pmrYes": "Yes",
+      "pmrNo": "No"
+    },
+    "timeRange": {
+      "MATIN": "05h — 10h",
+      "SOIR": "17h — 22h"
+    },
+    "nouveauVol": "New flight",
+    "prevWeek": "Previous week",
+    "nextWeek": "Next week",
     "organisation": {
       "title": "Flight organisation",
       "billetsDisponibles": "Available tickets",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -258,6 +258,7 @@
     "maxWind": "Vent max",
     "avgTemp": "OAT moy",
     "source": "Source: Open-Meteo.com",
+    "sourceFetchedAt": "Source : Open-Meteo (best match) — maj {date}",
     "fields": {
       "heure": "Heure",
       "vent10m": "Vent 10m",
@@ -508,6 +509,8 @@
     "devis": {
       "title": "Devis de masse",
       "temperature": "Température (C)",
+      "temperatureDefault": "(température par défaut)",
+      "insufficientData": "Données insuffisantes pour calculer le devis de masse (poids pilote ou quantité gaz manquants).",
       "poidsAVide": "Pesée à vide",
       "poidsGaz": "Gaz embarqué",
       "poidsPilote": "Pilote",
@@ -520,6 +523,19 @@
       "conforme": "CONFORME",
       "surcharge": "SURCHARGE"
     },
+    "passagers": {
+      "title": "Passagers ({count})",
+      "billet": "Billet",
+      "pmrYes": "Oui",
+      "pmrNo": "Non"
+    },
+    "timeRange": {
+      "MATIN": "05h — 10h",
+      "SOIR": "17h — 22h"
+    },
+    "nouveauVol": "Nouveau vol",
+    "prevWeek": "Semaine précédente",
+    "nextWeek": "Semaine suivante",
     "organisation": {
       "title": "Organisation du vol",
       "billetsDisponibles": "Billets disponibles",


### PR DESCRIPTION
## Contexte

Sweep de relecture sur les 4 phases de la refonte récentes (#25, #36, #37, #38) — simplification, qualité, sécurité / RGPD, a11y / UX. Seuls les findings réellement actionnables atterrissent dans cette PR ; le reste est synthétisé ci-dessous pour ta revue.

Tous les tests unitaires (135) passent, `typecheck` et `lint` propres.

## Résumé des changements

### i18n — vol detail + week grid + dashboard

- `app/[locale]/(app)/vols/[id]/page.tsx` : fin des chaînes françaises en dur (`Passagers (N)`, `Billet`, `Oui/Non`, `Donnees insuffisantes...`, `(temperature par defaut)`, `Source : Open-Meteo ... — maj {date}`). Au passage, les accents manquants sont réintroduits (`température`, `données`).
- `components/week-grid.tsx` : `aria-label="Nouveau vol"` / `"Previous week"` / `"Next week"` → clés `vols.nouveauVol / prevWeek / nextWeek`. Les flèches sont enveloppées dans `<span aria-hidden>` pour que les screen readers lisent le label localisé et pas `← / →`.
- `app/[locale]/(app)/page.tsx` : `CRENEAU_LABELS` (`"05h — 10h"`, `"17h — 22h"`) extrait en `vols.timeRange.{MATIN,SOIR}` — un helper `creneauRange()` remplace le `Record` local.

Nouvelles clés ajoutées dans `messages/fr.json` et `messages/en.json`, toujours en paire.

### DRY — date formatting

- `lib/format.ts` : ajout de `formatDateLong(date, locale)` et `formatDateTimeShort(date, locale)` — deux callers arrêtent de dupliquer le ternaire `locale === 'fr' ? 'fr-FR' : 'en-US'` + `toLocale...`. À adopter pour les prochaines vues.

### UX / a11y — FlightCard

- Meta grid : `grid-cols-2` inconditionnel → 1 colonne < 380 px, 2 colonnes au-delà. Sur téléphones étroits, Pilote / Équipier / Lieu / Capacité ne sont plus tronqués.
- Bandeau d'alerte météo : `dusk-50 / 200 / 700` → `dusk-100 / 300 / 800`. Contraste AAA (~8:1) sur une alerte sécurité — critique dans un cockpit.

## Ce qui n'est **pas** dans la PR (findings laissés pour que tu arbitres)

Je les ai listés mais volontairement pas traités — soit parce que l'impact est marginal, soit parce qu'ils méritent une décision produit plutôt qu'un patch à chaud.

### Sécurité / RGPD

- `vols/[id]/page.tsx:118` : `catch {}` muet sur l'appel météo → si la clé Open-Meteo tombe, l'exploitant ne voit rien. **Proposition :** logger l'échec dans l'audit log (sans PII) pour avoir une alerte ops.
- `vols/[id]/page.tsx:297` : le poids passager est affiché déchiffré dans le tableau, sur une page potentiellement cachée navigateur. À confirmer : headers `Cache-Control: no-store`, et peut-être masquer ce poids aux rôles non `ADMIN_CALPAX` / `GERANT` (cf. CLAUDE.md RGPD "accès restreint pilote + exploitant").
- Pas de rate-limit visible sur `getWeather()` côté dashboard (chaque chargement déclenche un appel si cache froid). Dépend de l'implémentation du cache — à vérifier.
- Les calculs / lectures du devis de masse (donnée de sécurité) ne génèrent pas d'entrée d'audit. Utile pour la traçabilité réglementaire ?

### Qualité

- `vol.creneau as 'MATIN' | 'SOIR'` : type-assertion répétée dans plusieurs fichiers. Un type guard `isCreneau()` ou un enum Prisma typé plus strictement éviterait les casts.
- `computeMassBudget()` (dashboard) et les types `MassBudget` / `WeatherSummary` existent à la fois dans `page.tsx` et `flight-card.tsx`. Ils pourraient être factorisés dans `lib/vol/flight-card-types.ts`.
- `mono cap text-[10px] text-sky-500` : pattern répété ~7 fois dans `flight-card.tsx` + `week-grid.tsx`. Candidat pour une utility Tailwind (`@utility label-mono`) ou un petit composant `<MonoLabel>`.

### UX / design à envisager

- **Loading state météo** : la requête est non-bloquante mais pas suspendue → flash de contenu quand elle arrive. Un `<Suspense>` avec skeleton sur la bande météo du `FlightCard` rendrait l'expérience plus stable.
- **Empty state dashboard** : `Plane` en `text-sky-300` sur fond `bg-card` → icône un peu fantôme. Monter à `sky-400` ou rendre le CTA plus affirmé.
- **Tooltip sur les chips de masse** (`OK` / `Limite` / `Dépassement`) : aujourd'hui l'opérateur voit une barre colorée, mais pas la **marge exacte** avant d'ouvrir le détail. Un tooltip au hover / tap avec `{chargeEmbarquee}/{maxPayload} kg` serait rapide à ajouter.
- **Date label dashboard** : le libellé complet (`lundi 22 avril 2026`) est long et se wrappe sur mobile. Pourrait devenir un `<time>` avec format court sur mobile et long sur desktop via breakpoint.

## Test plan

- [ ] `pnpm typecheck` ✓ (fait)
- [ ] `pnpm lint` ✓ (fait, 0 warning nouveau)
- [ ] `pnpm test` ✓ (135/135)
- [ ] Vérifier à l'œil la page `/fr/vols/[id]` et `/en/vols/[id]` — chaînes traduites, bandeau météo avec date locale
- [ ] Vérifier le dashboard `/fr` et `/en` — créneau `05h — 10h` / `17h — 22h` s'affichent bien via i18n
- [ ] Week grid : naviguer via clavier (Tab → Entrée), vérifier que screen reader annonce "Semaine précédente / suivante" et pas juste "←"
- [ ] Ouvrir un `FlightCard` sur un écran < 380 px (DevTools → iPhone SE) et vérifier 1 colonne ; bannière météo alert plus contrastée

https://claude.ai/code/session_01WzVvXCRHc6qEUgTeHX8YZD