### PR TITLE
quick-wins: dedupe types, mono-label, creneau casts, mass tooltip, dashboard polish

### DIFF
--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -11,7 +11,8 @@ import { summarizeWeather } from '@/lib/weather/classify'
 import { buildBallonAlerts, buildPiloteAlerts, sortAlerts } from '@/lib/regulatory/alerts'
 import { safeDecryptInt } from '@/lib/crypto'
 import { AlertsBanner } from '@/components/alerts-banner'
-import { FlightCard, type FlightCardData } from '@/components/flight-card'
+import { FlightCard } from '@/components/flight-card'
+import type { FlightCardData, MassBudget } from '@/lib/vol/flight-card-types'
 import { KpiRow, KpiTile } from '@/components/cockpit/kpi-tile'
 import { WindArrow } from '@/components/cockpit/wind-arrow'
 import { GoNogoWindow } from '@/components/cockpit/go-nogo-window'
@@ -21,7 +22,7 @@ import {
   type UpcomingFlight,
 } from '@/components/cockpit/upcoming-flights-table'
 import { Button } from '@/components/ui/button'
-import { formatDateLong } from '@/lib/format'
+import { formatDateLong, formatDateMedium } from '@/lib/format'
 import type { Prisma } from '@prisma/client'
 import type { WeatherForecast, WeatherSummary } from '@/lib/weather/types'
 
@@ -38,12 +39,6 @@ function camoStatusOf(
 
 type Props = {
   params: Promise<{ locale: string }>
-}
-
-type MassBudget = {
-  totalWeight: number
-  maxPayload: number
-  status: 'OK' | 'WARNING' | 'OVER'
 }
 
 type VolWithRelations = Prisma.VolGetPayload<{
@@ -227,12 +222,12 @@ export default async function HomePage({ params }: Props) {
 
     // 5. Map vols to FlightCardData
     const cards: FlightCardData[] = vols.map((vol) => {
-      const weatherSummary = getWeatherForCreneau(vol.creneau as 'MATIN' | 'SOIR')
+      const weatherSummary = getWeatherForCreneau(vol.creneau)
       const forecastTemp = weatherSummary?.avgTemperature ?? null
       return {
         id: vol.id,
         date: todayStr,
-        creneau: vol.creneau as 'MATIN' | 'SOIR',
+        creneau: vol.creneau,
         statut: vol.statut,
         ballonNom: vol.ballon.nom,
         ballonImmat: vol.ballon.immatriculation,
@@ -255,7 +250,7 @@ export default async function HomePage({ params }: Props) {
       if (!nextFlightByBallon.has(uv.ballon.id)) {
         nextFlightByBallon.set(uv.ballon.id, {
           date: uv.date.toISOString().slice(0, 10),
-          creneau: uv.creneau as 'MATIN' | 'SOIR',
+          creneau: uv.creneau,
         })
       }
     }
@@ -272,7 +267,7 @@ export default async function HomePage({ params }: Props) {
     const upcomingFlights: UpcomingFlight[] = upcomingVolsRaw.slice(0, 7).map((uv) => ({
       id: uv.id,
       date: uv.date.toISOString().slice(0, 10),
-      creneau: uv.creneau as 'MATIN' | 'SOIR',
+      creneau: uv.creneau,
       statut: uv.statut,
       ballonImmat: uv.ballon.immatriculation,
       ballonNom: uv.ballon.nom,
@@ -294,7 +289,8 @@ export default async function HomePage({ params }: Props) {
     const paxBooked = cards.reduce((sum, c) => sum + c.passagerCount, 0)
     const paxSeats = cards.reduce((sum, c) => sum + c.passagerMax, 0)
 
-    const dateLabel = formatDateLong(today, locale)
+    const dateLabelLong = formatDateLong(today, locale)
+    const dateLabelShort = formatDateMedium(today, locale)
 
     return (
       <div className="space-y-6">
@@ -306,7 +302,8 @@ export default async function HomePage({ params }: Props) {
               {t('title')}
             </h1>
             <div className="mono text-[11px] text-sky-500">
-              <span className="cap">{dateLabel}</span>
+              <span className="cap hidden sm:inline">{dateLabelLong}</span>
+              <span className="cap sm:hidden">{dateLabelShort}</span>
               <span className="mx-2 opacity-50">·</span>
               <span>{t('flightCount', { count: vols.length })}</span>
             </div>
@@ -349,7 +346,7 @@ export default async function HomePage({ params }: Props) {
 
         {vols.length === 0 ? (
           <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-sky-200 bg-card py-16 text-center">
-            <Plane className="mb-4 h-12 w-12 text-sky-300" aria-hidden />
+            <Plane className="mb-4 h-12 w-12 text-sky-400" aria-hidden />
             <p className="mb-4 text-sky-500">{t('noFlights')}</p>
             <Button asChild variant="outline">
               <Link href={`/${locale}/vols`}>{t('goToPlanning')}</Link>

--- a/app/[locale]/(app)/vols/[id]/page.tsx
+++ b/app/[locale]/(app)/vols/[id]/page.tsx
@@ -101,7 +101,7 @@ export default async function VolDetailPage({ params }: Props) {
           longitude: vol.exploitant.meteoLongitude,
           date: dateStr,
         })
-        weatherHours = extractCreneauHours(forecast, vol.creneau as 'MATIN' | 'SOIR')
+        weatherHours = extractCreneauHours(forecast, vol.creneau)
         weatherSummary = summarizeWeather(weatherHours, seuilVent)
 
         const cached = await db.weatherCache.findUnique({

--- a/app/[locale]/(app)/vols/page.tsx
+++ b/app/[locale]/(app)/vols/page.tsx
@@ -31,7 +31,7 @@ function toDateOnly(date: Date): string {
 function mapVolToCardData(vol: {
   id: string
   date: Date
-  creneau: string
+  creneau: 'MATIN' | 'SOIR'
   statut: string
   ballon: { nom: string; immatriculation: string; nbPassagerMax: number }
   pilote: { prenom: string; nom: string }
@@ -50,7 +50,7 @@ function mapVolToCardData(vol: {
   return {
     id: vol.id,
     date: toDateOnly(vol.date),
-    creneau: vol.creneau as 'MATIN' | 'SOIR',
+    creneau: vol.creneau,
     statut: vol.statut,
     ballonNom: vol.ballon.nom,
     ballonImmat: vol.ballon.immatriculation,
@@ -107,7 +107,7 @@ export default async function VolsPage({ params, searchParams }: Props) {
     const weekVols: VolSummary[] = volsRaw.map((vol) => ({
       id: vol.id,
       date: toDateOnly(vol.date),
-      creneau: vol.creneau as 'MATIN' | 'SOIR',
+      creneau: vol.creneau,
       ballonNom: vol.ballon.nom,
       piloteInitiales:
         (vol.pilote.prenom[0] ?? '').toUpperCase() + (vol.pilote.nom[0] ?? '').toUpperCase(),

--- a/app/[locale]/auth/signin/page.tsx
+++ b/app/[locale]/auth/signin/page.tsx
@@ -8,6 +8,7 @@ import { authClient, signIn } from '@/lib/auth-client'
 import { DismissibleError } from '@/components/auth/dismissible-error'
 import { PasswordInput } from '@/components/auth/password-input'
 import { CalpaxWordmark } from '@/components/brand/calpax-wordmark'
+import { MonoLabel } from '@/components/cockpit/mono-label'
 import { StatusDot } from '@/components/cockpit/status-dot'
 import { TopoPattern } from '@/components/cockpit/topo-pattern'
 
@@ -375,7 +376,7 @@ function SigninForm({
 
       <div className="my-4 flex items-center gap-3">
         <div className="h-px flex-1 bg-sky-100" />
-        <span className="mono cap text-[10px] text-sky-500">{t('orContinueWith')}</span>
+        <MonoLabel>{t('orContinueWith')}</MonoLabel>
         <div className="h-px flex-1 bg-sky-100" />
       </div>
 

--- a/app/api/cron/meteo-alert/route.ts
+++ b/app/api/cron/meteo-alert/route.ts
@@ -126,7 +126,7 @@ export async function GET(request: Request): Promise<Response> {
     const threshold = exp.meteoSeuilVent ?? 15
 
     for (const vol of expVols) {
-      const hours = extractCreneauHours(forecast, vol.creneau as 'MATIN' | 'SOIR')
+      const hours = extractCreneauHours(forecast, vol.creneau)
       const summary = summarizeWeather(hours, threshold)
       const shouldAlert = summary.level !== 'OK'
 

--- a/components/cockpit/mono-label.tsx
+++ b/components/cockpit/mono-label.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type MonoLabelProps = {
+  as?: 'span' | 'div'
+  children: React.ReactNode
+  className?: string
+}
+
+/**
+ * Micro-label cockpit — font-mono + uppercase + letter-spacing + 10px sky-500.
+ * Used for every "meta" label above a value (field labels, section kickers,
+ * table headers) to keep typography consistent.
+ */
+export function MonoLabel({ as: Tag = 'span', children, className }: MonoLabelProps) {
+  return <Tag className={cn('mono cap text-[10px] text-sky-500', className)}>{children}</Tag>
+}

--- a/components/flight-card.tsx
+++ b/components/flight-card.tsx
@@ -2,43 +2,17 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { AlertTriangle, Thermometer } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Chip } from '@/components/cockpit/chip'
 import { LoadBar } from '@/components/cockpit/load-bar'
 import { MonoValue } from '@/components/cockpit/mono-value'
 import { WindArrow } from '@/components/cockpit/wind-arrow'
+import { MonoLabel } from '@/components/cockpit/mono-label'
 import { cn } from '@/lib/utils'
 import type { UserRole } from '@/lib/context'
+import type { FlightCardData, FlightCardWeather, MassBudget } from '@/lib/vol/flight-card-types'
 
-type MassBudget = {
-  totalWeight: number
-  maxPayload: number
-  status: 'OK' | 'WARNING' | 'OVER'
-}
-
-type WeatherSummary = {
-  maxWindKt: number
-  maxWindAltitude: string
-  avgTemperature: number
-  goNogo: 'GO' | 'NOGO' | 'MARGINAL'
-  creneauRange: string
-}
-
-export type FlightCardData = {
-  id: string
-  date: string
-  creneau: 'MATIN' | 'SOIR'
-  statut: string
-  ballonNom: string
-  ballonImmat: string
-  piloteNom: string
-  equipierNom: string | null
-  siteDeco: string | null
-  passagerCount: number
-  passagerMax: number
-  massBudget: MassBudget | null
-  weather: WeatherSummary | null
-  meteoAlert: boolean
-}
+export type { FlightCardData } from '@/lib/vol/flight-card-types'
 
 type Props = {
   flight: FlightCardData
@@ -75,7 +49,7 @@ const MASS_LABEL_KEY: Record<MassBudget['status'], string> = {
   OVER: 'massOver',
 }
 
-const GONOGO_CHIP: Record<WeatherSummary['goNogo'], Parameters<typeof Chip>[0]['tone']> = {
+const GONOGO_CHIP: Record<FlightCardWeather['goNogo'], Parameters<typeof Chip>[0]['tone']> = {
   GO: 'ok',
   NOGO: 'danger',
   MARGINAL: 'warn',
@@ -134,7 +108,7 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
         <MetaField label={tv('fields.equipier')} value={flight.equipierNom ?? '—'} />
         <MetaField label={tv('fields.lieuDecollage')} value={flight.siteDeco ?? '—'} />
         <div className="space-y-1">
-          <div className="mono cap text-[10px] text-sky-500">{t('capacity')}</div>
+          <MonoLabel as="div">{t('capacity')}</MonoLabel>
           <LoadBar
             value={flight.passagerCount}
             max={flight.passagerMax}
@@ -148,10 +122,27 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
       {flight.massBudget ? (
         <div className="space-y-1.5 rounded-md bg-sky-50 px-3 py-2.5">
           <div className="flex items-center justify-between gap-2">
-            <span className="mono cap text-[10px] text-sky-500">{t('massLabel')}</span>
-            <Chip tone={MASS_CHIP[flight.massBudget.status]} size="sm">
-              {t(MASS_LABEL_KEY[flight.massBudget.status])}
-            </Chip>
+            <MonoLabel>{t('massLabel')}</MonoLabel>
+            <TooltipProvider delayDuration={150}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Chip tone={MASS_CHIP[flight.massBudget.status]} size="sm">
+                      {t(MASS_LABEL_KEY[flight.massBudget.status])}
+                    </Chip>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <span className="mono">
+                    {t('massTooltip', {
+                      charge: flight.massBudget.totalWeight,
+                      max: flight.massBudget.maxPayload,
+                      marge: flight.massBudget.maxPayload - flight.massBudget.totalWeight,
+                    })}
+                  </span>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
           <LoadBar
             value={flight.massBudget.totalWeight}
@@ -171,9 +162,9 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
       {/* Weather strip */}
       {flight.weather && (
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md bg-sky-50 px-3 py-2 text-sm">
-          <span className="mono cap text-[10px] text-sky-500">
+          <MonoLabel>
             {tv(`creneau.${flight.creneau}`)} · {flight.weather.creneauRange}
-          </span>
+          </MonoLabel>
           <div className="flex items-center gap-1.5 text-sky-700">
             <WindArrow
               direction={0}
@@ -214,7 +205,7 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
 function MetaField({ label, value }: { label: string; value: string }) {
   return (
     <div className="space-y-0.5 min-w-0">
-      <div className="mono cap text-[10px] text-sky-500">{label}</div>
+      <MonoLabel as="div">{label}</MonoLabel>
       <div className="truncate font-medium text-sky-900">{value}</div>
     </div>
   )

--- a/components/week-grid.tsx
+++ b/components/week-grid.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { Plus } from 'lucide-react'
 import { Chip } from '@/components/cockpit/chip'
+import { MonoLabel } from '@/components/cockpit/mono-label'
 import { MonoValue } from '@/components/cockpit/mono-value'
 import { EmptyState } from '@/components/empty-state'
 import { cn } from '@/lib/utils'
@@ -174,7 +175,7 @@ export function WeekGrid({
               key={day}
               className="flex flex-col items-center gap-0.5 border-b border-r border-sky-100 bg-sky-50 px-2 py-2 last:border-r-0"
             >
-              <div className="mono cap text-[10px] text-sky-500">{DAY_SHORT[i]}</div>
+              <MonoLabel as="div">{DAY_SHORT[i]}</MonoLabel>
               <div className="mono text-[12px] font-medium text-sky-900">
                 {formatShortDate(day)}
               </div>

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -19,6 +19,14 @@ export function formatDateLong(date: Date, locale: string): string {
   })
 }
 
+export function formatDateMedium(date: Date, locale: string): string {
+  return date.toLocaleDateString(localeTag(locale), {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
 export function formatDateTimeShort(date: Date, locale: string): string {
   return date.toLocaleString(localeTag(locale), {
     day: '2-digit',

--- a/lib/pdf/build-data.ts
+++ b/lib/pdf/build-data.ts
@@ -58,7 +58,7 @@ export async function buildFicheVolData(
         longitude: vol.exploitant.meteoLongitude,
         date: dateStr,
       })
-      const hours = extractCreneauHours(forecast, vol.creneau as 'MATIN' | 'SOIR')
+      const hours = extractCreneauHours(forecast, vol.creneau)
       const summary = summarizeWeather(hours, seuilVent)
       meteo = { hours, summary, seuilVent }
     } catch {
@@ -76,7 +76,7 @@ export async function buildFicheVolData(
     exploitant: vol.exploitant,
     vol: {
       date: vol.date,
-      creneau: vol.creneau as 'MATIN' | 'SOIR',
+      creneau: vol.creneau,
       lieuDecollage: lieuDecollageDisplay,
       equipier: equipierDisplay,
       vehicule: vehiculeDisplay,

--- a/lib/vol/flight-card-types.ts
+++ b/lib/vol/flight-card-types.ts
@@ -1,0 +1,34 @@
+// Types shared between the dashboard page and the FlightCard component.
+// Kept separate from the Prisma-level `WeatherSummary` in lib/weather/types.ts
+// — this is the UI-shaped projection used for rendering.
+
+export type MassBudget = {
+  totalWeight: number
+  maxPayload: number
+  status: 'OK' | 'WARNING' | 'OVER'
+}
+
+export type FlightCardWeather = {
+  maxWindKt: number
+  maxWindAltitude: string
+  avgTemperature: number
+  goNogo: 'GO' | 'NOGO' | 'MARGINAL'
+  creneauRange: string
+}
+
+export type FlightCardData = {
+  id: string
+  date: string
+  creneau: 'MATIN' | 'SOIR'
+  statut: string
+  ballonNom: string
+  ballonImmat: string
+  piloteNom: string
+  equipierNom: string | null
+  siteDeco: string | null
+  passagerCount: number
+  passagerMax: number
+  massBudget: MassBudget | null
+  weather: FlightCardWeather | null
+  meteoAlert: boolean
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -714,6 +714,7 @@
     "massOk": "OK",
     "massWarning": "Marginal",
     "massOver": "Overweight",
+    "massTooltip": "{charge} / {max} kg · margin {marge} kg",
     "massUnavailable": "Mass budget unavailable (no passengers or weather data missing)",
     "goNogo": {
       "GO": "GO",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -714,6 +714,7 @@
     "massOk": "OK",
     "massWarning": "Limite",
     "massOver": "Dépassement",
+    "massTooltip": "{charge} / {max} kg · marge {marge} kg",
     "massUnavailable": "Devis de masse non calculable (pas de passagers ou données météo manquantes)",
     "goNogo": {
       "GO": "GO",


### PR DESCRIPTION
## Summary

Batch 1 des follow-ups PR #40 — 5 cleanups à faible risque regroupés en une seule PR parce que chacun est petit.

## Ce qui est livré

### 🔧 #46 — dedupe types
- Nouveau `lib/vol/flight-card-types.ts` → source unique pour `FlightCardData`, `MassBudget`, `FlightCardWeather`
- `components/flight-card.tsx` et `app/[locale]/(app)/page.tsx` importent depuis ce module
- `FlightCardWeather` (au lieu de `WeatherSummary`) pour éviter le shadowing du type de `lib/weather/types.ts`

### 🧩 #47 — MonoLabel component
- `components/cockpit/mono-label.tsx` encapsule `mono cap text-[10px] text-sky-500`
- 6 call sites migrés (`flight-card.tsx`, `week-grid.tsx`, `signin/page.tsx`)
- Le TR de `upcoming-flights-table` est gardé tel quel (pattern sur la row, pas sur chaque cell — migration plus invasive)

### ✂️ #45 — casts `creneau` redondants supprimés
- Prisma type déjà `$Enums.Creneau = "MATIN" | "SOIR"` → les `as 'MATIN' | 'SOIR'` étaient tous des no-ops
- Supprimé dans : dashboard, vols list, vols detail, cron `meteo-alert`, `lib/pdf/build-data`
- Le type inline de `mapVolToCardData` resserré de `creneau: string` à la literal union pour éviter de re-cast

### 💡 #49 — tooltip sur chip masse
- `<Tooltip>` shadcn autour du chip `OK / Limite / Dépassement`
- Contenu : `{charge} / {max} kg · marge {marge} kg`
- Nouvelle clé i18n `dashboard.massTooltip` (fr/en)

### 🎨 #50 — dashboard polish
- Icône `Plane` empty-state : `text-sky-300` → `text-sky-400`
- Date header responsive : `formatDateLong` sur `sm+`, nouveau `formatDateMedium` (`22 avr 2026`) sous `sm`
- `lib/format.ts` gagne `formatDateMedium(date, locale)`

## Closes

Closes #45, #46, #47, #49, #50

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [x] `pnpm run lint` — via lint-staged hook au commit
- [ ] Vercel preview : tooltip au hover/focus sur chip masse, date header responsive < 640px, empty-state dashboard

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32