### PR TITLE
typo: swap Geist Mono for JetBrains Mono

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Archivo, DM_Sans, Geist_Mono } from 'next/font/google'
+import { Archivo, DM_Sans, JetBrains_Mono } from 'next/font/google'
 import { cn } from '@/lib/utils'
 import { Toaster } from '@/components/ui/sonner'
 
@@ -17,8 +17,8 @@ const archivo = Archivo({
   display: 'swap',
   weight: ['400', '500', '600', '700'],
 })
-// Geist Mono = data tabulaire (immats, heures, masses)
-const geistMono = Geist_Mono({
+// JetBrains Mono = data tabulaire (immats, heures, masses)
+const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
   variable: '--font-mono',
   display: 'swap',
@@ -32,7 +32,7 @@ const geistMono = Geist_Mono({
  */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html className={cn('font-sans', dmSans.variable, archivo.variable, geistMono.variable)}>
+    <html className={cn('font-sans', dmSans.variable, archivo.variable, jetbrainsMono.variable)}>
       <body>
         {children}
         <Toaster />


### PR DESCRIPTION
## Summary

Swap de la font mono : **Geist Mono → JetBrains Mono**.

## Pourquoi

JetBrains Mono lit mieux que Geist aux petites tailles (10-12px) — ce qui importe puisque toutes les immats, heures, masses, compteurs PAX dans le cockpit UI sont rendus dans cette taille. Les chiffres tabulaires sont plus distinctifs et la personnalité "technique-aviation" colle mieux au thème Crépuscule.

## Ce qui change

- `app/layout.tsx` : `Geist_Mono` → `JetBrains_Mono` (même import `next/font/google`)
- Même variable CSS `--font-mono` → **aucun** autre fichier à toucher, tous les `mono`-classed elements / `MonoValue` / `MonoLabel` adoptent la nouvelle font automatiquement

## Test plan

- [x] `pnpm run typecheck` — clean
- [ ] Vercel preview : regarder le bandeau vol detail, KPI tiles dashboard, chips PAX dans la week grid, stats login

Si tu veux essayer IBM Plex Mono ou Commit Mono à la place, c'est un 2-caractère swap après merge.

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32