### PR TITLE
rgpd(#42): Cache-Control no-store + role-gate decrypted passenger weight

### DIFF
--- a/app/[locale]/(app)/billets/[id]/page.tsx
+++ b/app/[locale]/(app)/billets/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireRole } from '@/lib/auth/requireRole'
 import { db } from '@/lib/db'
 import { safeDecryptInt } from '@/lib/crypto'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -70,6 +71,9 @@ function statutPaiementVariant(
 export default async function BilletDetailPage({ params }: Props) {
   const { locale, id } = await params
   return requireAuth(async () => {
+    // Billets hold payer contact + decrypted passenger weights — admin/gerant only.
+    requireRole('ADMIN_CALPAX', 'GERANT')
+
     const tBillets = await getTranslations('billets')
     const tPaiements = await getTranslations('paiements')
     const tPassagers = await getTranslations('passagers')

--- a/app/[locale]/(app)/vols/[id]/page.tsx
+++ b/app/[locale]/(app)/vols/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { requireAuth } from '@/lib/auth/requireAuth'
+import { canSeePassengerWeight } from '@/lib/auth/rgpd'
 import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
 import { safeDecryptInt } from '@/lib/crypto'
@@ -79,6 +80,13 @@ export default async function VolDetailPage({ params }: Props) {
     if (!vol) notFound()
 
     const tMeteo = await getTranslations('meteo')
+
+    // RGPD: only admin/gerant or the assigned pilote see decrypted passenger weights.
+    const canSeePoids = canSeePassengerWeight({
+      role: ctx.role,
+      piloteUserId: vol.pilote.userId ?? null,
+      currentUserId: ctx.userId,
+    })
 
     const pilotePoidsRaw = vol.pilote.poidsEncrypted
     const pilotePoids = pilotePoidsRaw ? safeDecryptInt(pilotePoidsRaw) : null
@@ -284,20 +292,27 @@ export default async function VolDetailPage({ params }: Props) {
                       </TableHead>
                       <TableHead className={labelClassName}>{tPassagers('fields.nom')}</TableHead>
                       <TableHead className={labelClassName}>{tPassagers('fields.age')}</TableHead>
-                      <TableHead className={labelClassName}>{tPassagers('fields.poids')}</TableHead>
+                      {canSeePoids && (
+                        <TableHead className={labelClassName}>
+                          {tPassagers('fields.poids')}
+                        </TableHead>
+                      )}
                       <TableHead className={labelClassName}>{tPassagers('fields.pmr')}</TableHead>
                       <TableHead className={labelClassName}>{tVolPassagers('billet')}</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {vol.passagers.map((p) => {
-                      const poids = p.poidsEncrypted ? safeDecryptInt(p.poidsEncrypted) : null
+                      const poids =
+                        canSeePoids && p.poidsEncrypted ? safeDecryptInt(p.poidsEncrypted) : null
                       return (
                         <TableRow key={p.id} className="hover:bg-muted/50">
                           <TableCell>{p.prenom}</TableCell>
                           <TableCell>{p.nom}</TableCell>
                           <TableCell>{p.age ?? '—'}</TableCell>
-                          <TableCell>{poids !== null ? `${poids} kg` : '—'}</TableCell>
+                          {canSeePoids && (
+                            <TableCell>{poids !== null ? `${poids} kg` : '—'}</TableCell>
+                          )}
                           <TableCell>
                             {p.pmr ? tVolPassagers('pmrYes') : tVolPassagers('pmrNo')}
                           </TableCell>

--- a/lib/auth/rgpd.ts
+++ b/lib/auth/rgpd.ts
@@ -1,0 +1,23 @@
+import type { UserRole } from '@/lib/context'
+
+/**
+ * Passenger weight is RGPD-sensitive (CLAUDE.md: "accès restreint pilote +
+ * exploitant"). Only ADMIN_CALPAX and GERANT can always see it; a PILOTE
+ * can see it on vols where they are the assigned pilot (via Pilote.userId
+ * matching the session user); EQUIPIER never sees it.
+ */
+export function canSeePassengerWeight(args: {
+  role: UserRole
+  /**
+   * When gating inside a single vol, pass the vol's pilote `userId` so a
+   * PILOTE viewing their own vol is allowed. Omit when the context has no
+   * single owning pilote (e.g. billet list / detail).
+   */
+  piloteUserId?: string | null
+  currentUserId?: string
+}): boolean {
+  const { role, piloteUserId, currentUserId } = args
+  if (role === 'ADMIN_CALPAX' || role === 'GERANT') return true
+  if (role === 'PILOTE' && piloteUserId && piloteUserId === currentUserId) return true
+  return false
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,7 +40,16 @@ export default function middleware(request: NextRequest) {
     }
   }
 
-  return intlMiddleware(request)
+  const response = intlMiddleware(request)
+
+  if (isProtectedPath(pathname)) {
+    // Protected routes may serve decrypted PII (poids passagers, coordonnées,
+    // etc.) embedded in RSC payloads. Prevent any shared or browser cache
+    // from retaining those bytes past the session.
+    response.headers.set('Cache-Control', 'private, no-store')
+  }
+
+  return response
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

Traite #42 — deux volets RGPD sur l'affichage/cache des poids passagers déchiffrés.

## Changements

### 1. Middleware — `Cache-Control: private, no-store`

`middleware.ts` applique désormais ce header sur toutes les réponses de paths protégés (post-intl). Les payloads RSC embarquent parfois du PII déchiffré (`12 kg`, coordonnées, nom payeur) dans le HTML — le no-store empêche le cache navigateur/proxy partagé de conserver ces bytes après déconnexion.

### 2. Prédicat RGPD centralisé

Nouveau `lib/auth/rgpd.ts` → `canSeePassengerWeight({ role, piloteUserId, currentUserId })`.

Règle unique (alignée sur CLAUDE.md « accès restreint pilote + exploitant ») :

| Rôle | Condition |
|---|---|
| `ADMIN_CALPAX` | toujours autorisé |
| `GERANT` | toujours autorisé |
| `PILOTE` | uniquement si `vol.pilote.userId === session.userId` |
| `EQUIPIER` | **jamais** |

### 3. Vol detail (`vols/[id]/page.tsx`)

- `canSeePoids` calculé une fois, puis la colonne poids (TableHead + TableCell) est **entièrement omise** pour les rôles non autorisés — pas un `—` masqué, pour ne pas fuiter l'existence de la donnée
- `safeDecryptInt` skippé quand l'accès n'est pas autorisé

### 4. Billet detail (`billets/[id]/page.tsx`)

- Ajout de `requireRole('ADMIN_CALPAX', 'GERANT')` au niveau page. La sidebar masquait déjà `billets` aux PILOTE/EQUIPIER, mais **un accès direct via URL aurait affiché poids + coordonnées payeur sans garde serveur**. Ce commit ferme ce trou.

## Zéro impact fonctionnel

- Pas de changement i18n
- Pas de changement data model
- RBAC : on **durcit** pour PILOTE/EQUIPIER uniquement ; ADMIN/GERANT inchangés

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : se logger en PILOTE (non assigné au vol) → colonne poids absente sur `/vols/[id]` ; se logger en EQUIPIER → colonne poids absente ; PILOTE assigné → colonne poids visible
- [ ] Tenter l'accès direct à `/billets/[id]` en PILOTE/EQUIPIER → 403 au lieu de la page complète
- [ ] Vérifier `response.headers.get('cache-control')` = `private, no-store` sur une requête `/fr/vols/[id]` loggée

Closes #42.

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32