### PR TITLE
audit(#41 #44): trace weather-fetch failures and mass-budget reads

### DIFF
--- a/app/[locale]/(app)/vols/[id]/page.tsx
+++ b/app/[locale]/(app)/vols/[id]/page.tsx
@@ -1,8 +1,10 @@
 import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import { AuditAction } from '@prisma/client'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { canSeePassengerWeight } from '@/lib/auth/rgpd'
+import { writeAudit } from '@/lib/audit/write'
 import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
 import { safeDecryptInt } from '@/lib/crypto'
@@ -143,6 +145,29 @@ export default async function VolDetailPage({ params }: Props) {
             qteGaz: vol.qteGaz ?? parseQteGazFromConfig(vol.configGaz ?? vol.ballon.configGaz) ?? 0,
           })
         : null
+
+    // Regulatory traceability: emit an audit row whenever the mass budget is
+    // actually computed (Part-BOP investigations may need to reconstruct what
+    // the operator saw at planning time). No PII — only numeric weights and
+    // the temperature that drove the reading.
+    if (devis) {
+      await writeAudit({
+        exploitantId: vol.exploitantId,
+        userId: ctx.userId,
+        impersonatedBy: ctx.impersonatedBy ?? null,
+        entityType: 'DevisMasse',
+        entityId: vol.id,
+        action: AuditAction.CREATE,
+        afterValue: {
+          chargeEmbarquee: devis.chargeEmbarquee,
+          chargeUtileMax: devis.chargeUtileMax,
+          margeRestante: devis.margeRestante,
+          estSurcharge: devis.estSurcharge,
+          temperatureCelsius: devisTemperature,
+          source: weatherSummary ? 'forecast' : 'default',
+        },
+      })
+    }
 
     const labelClassName = 'text-xs uppercase tracking-wider text-muted-foreground'
 

--- a/lib/audit/write.ts
+++ b/lib/audit/write.ts
@@ -1,0 +1,44 @@
+import { Prisma, AuditAction } from '@prisma/client'
+import { basePrisma } from '@/lib/db/base'
+import { logger } from '@/lib/logger'
+
+type AuditInput = {
+  exploitantId?: string | null
+  userId?: string | null
+  impersonatedBy?: string | null
+  entityType: string
+  entityId: string
+  action: AuditAction
+  field?: string | null
+  beforeValue?: Prisma.InputJsonValue | null
+  afterValue?: Prisma.InputJsonValue | null
+}
+
+/**
+ * Write a single audit-log row for an operation that isn't a plain Prisma
+ * CRUD (those are captured by `audit-extension.ts` automatically). Use this
+ * for cross-cutting events such as weather-fetch failures, mass-budget
+ * reads, or admin actions that bypass the tenant-scoped client.
+ *
+ * Failures are logged and swallowed — audit must never be on the critical
+ * path of the request.
+ */
+export async function writeAudit(input: AuditInput): Promise<void> {
+  try {
+    await basePrisma.auditLog.create({
+      data: {
+        exploitantId: input.exploitantId ?? null,
+        userId: input.userId ?? null,
+        impersonatedBy: input.impersonatedBy ?? null,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        action: input.action,
+        field: input.field ?? null,
+        beforeValue: input.beforeValue ?? Prisma.DbNull,
+        afterValue: input.afterValue ?? Prisma.DbNull,
+      },
+    })
+  } catch (err) {
+    logger.error({ err, ...input }, 'writeAudit: failed to persist audit row')
+  }
+}

--- a/lib/weather/cache.ts
+++ b/lib/weather/cache.ts
@@ -1,4 +1,6 @@
+import { AuditAction } from '@prisma/client'
 import { db } from '@/lib/db'
+import { writeAudit } from '@/lib/audit/write'
 import { fetchWeatherFromAPI } from './open-meteo'
 import { parseOpenMeteoResponse } from './parse'
 import type { WeatherForecast } from './types'
@@ -17,37 +19,55 @@ type GetWeatherParams = {
 export async function getWeather(params: GetWeatherParams): Promise<WeatherForecast> {
   const { exploitantId, latitude, longitude, date, forceRefresh } = params
 
-  if (!forceRefresh) {
-    const cached = await db.weatherCache.findUnique({
-      where: { exploitantId_date: { exploitantId, date: new Date(date + 'T00:00:00Z') } },
-    })
+  try {
+    if (!forceRefresh) {
+      const cached = await db.weatherCache.findUnique({
+        where: { exploitantId_date: { exploitantId, date: new Date(date + 'T00:00:00Z') } },
+      })
 
-    if (cached) {
-      const age = Date.now() - cached.fetchedAt.getTime()
-      if (age < CACHE_TTL_MS) {
-        return parseOpenMeteoResponse(cached.data as OpenMeteoResponse, date)
+      if (cached) {
+        const age = Date.now() - cached.fetchedAt.getTime()
+        if (age < CACHE_TTL_MS) {
+          return parseOpenMeteoResponse(cached.data as OpenMeteoResponse, date)
+        }
       }
     }
-  }
 
-  const response = await fetchWeatherFromAPI({ latitude, longitude, date })
+    const response = await fetchWeatherFromAPI({ latitude, longitude, date })
 
-  await db.weatherCache.upsert({
-    where: { exploitantId_date: { exploitantId, date: new Date(date + 'T00:00:00Z') } },
-    update: {
-      data: response as object,
-      fetchedAt: new Date(),
-      latitude,
-      longitude,
-    },
-    create: {
+    await db.weatherCache.upsert({
+      where: { exploitantId_date: { exploitantId, date: new Date(date + 'T00:00:00Z') } },
+      update: {
+        data: response as object,
+        fetchedAt: new Date(),
+        latitude,
+        longitude,
+      },
+      create: {
+        exploitantId,
+        date: new Date(date + 'T00:00:00Z'),
+        data: response as object,
+        latitude,
+        longitude,
+      },
+    })
+
+    return parseOpenMeteoResponse(response, date)
+  } catch (err) {
+    // Emit a best-effort audit entry so super-admins notice repeated Open-Meteo
+    // outages in the audit view instead of a silent `catch {}` at the call site.
+    // No PII here — only exploitant + date + error message.
+    await writeAudit({
       exploitantId,
-      date: new Date(date + 'T00:00:00Z'),
-      data: response as object,
-      latitude,
-      longitude,
-    },
-  })
-
-  return parseOpenMeteoResponse(response, date)
+      entityType: 'Weather',
+      entityId: `${exploitantId}:${date}`,
+      action: AuditAction.UPDATE,
+      field: 'fetch_failed',
+      afterValue: {
+        date,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    })
+    throw err
+  }
 }


### PR DESCRIPTION
## Summary

Traite **#41** + **#44** dans une seule PR (les deux étendent l'audit log).

## Nouveau helper : `lib/audit/write.ts`

Petit wrapper autour de `basePrisma.auditLog.create` avec logging d'erreur structuré. Destiné aux événements **cross-cutting** qui ne sont pas du CRUD Prisma pur (ceux-ci sont déjà captés par `audit-extension.ts`). Les écritures d'audit ne sont jamais sur le chemin critique : toute erreur est logguée puis silenced.

## #41 — trace failures de `getWeather()`

`lib/weather/cache.ts` : wrap de la fonction dans un try/catch qui, sur échec de fetch Open-Meteo :

- Émet une ligne audit `entityType: 'Weather'`, `action: UPDATE`, `field: 'fetch_failed'`, `afterValue: { date, error }` — aucun PII
- **Re-throw** l'erreur pour que les `catch {}` silencieux côté appelants continuent à masquer la dégradation UI

Impact : les outages Open-Meteo deviennent visibles dans la vue audit super-admin.

## #44 — trace des calculs de devis de masse

`app/[locale]/(app)/vols/[id]/page.tsx` : après `calculerDevisMasse()`, émet une ligne audit pour la traçabilité réglementaire Part-BOP.

```json
{
  "entityType": "DevisMasse",
  "entityId": "<volId>",
  "action": "CREATE",
  "afterValue": {
    "chargeEmbarquee": 473,
    "chargeUtileMax": 680,
    "margeRestante": 207,
    "estSurcharge": false,
    "temperatureCelsius": 15,
    "source": "forecast"
  }
}
```

Aucun PII — uniquement les valeurs numériques agrégées + la température utilisée pour la lecture du chart.

## Convention d'enum

Utilise les valeurs existantes `AuditAction.UPDATE` / `CREATE` avec `entityType` métier (`'Weather'`, `'DevisMasse'`) — même pattern que l'audit explicite `User.banned` dans `lib/actions/admin.ts`. **Pas de migration schéma nécessaire.**

## Closes

Closes #41, #44.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : couper la connexion Open-Meteo (ou mocker), recharger `/fr` → vérifier une ligne audit `Weather/fetch_failed`
- [ ] Visiter `/fr/vols/[id]` → vérifier une ligne audit `DevisMasse/<volId>/CREATE` avec les bonnes valeurs

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32