### PR TITLE
perf(#43): in-flight coalescing for getWeather

### DIFF
--- a/lib/weather/cache.ts
+++ b/lib/weather/cache.ts
@@ -8,6 +8,17 @@ import type { OpenMeteoResponse } from './parse'
 
 const CACHE_TTL_MS = 30 * 60 * 1000 // 30 minutes
 
+/**
+ * Per-instance in-flight deduplication: coalesces concurrent `getWeather()`
+ * calls for the same `(exploitantId, date)` so a cache-miss burst only hits
+ * Open-Meteo once. Entries are removed as soon as the promise settles.
+ *
+ * This is intentionally in-memory (Map) — a single Vercel serverless
+ * invocation rarely needs more, and cross-instance coalescing would require
+ * Redis which isn't in the stack today.
+ */
+const inFlight = new Map<string, Promise<WeatherForecast>>()
+
 type GetWeatherParams = {
   exploitantId: string
   latitude: number
@@ -17,6 +28,24 @@ type GetWeatherParams = {
 }
 
 export async function getWeather(params: GetWeatherParams): Promise<WeatherForecast> {
+  const { exploitantId, date, forceRefresh } = params
+
+  if (!forceRefresh) {
+    const pending = inFlight.get(`${exploitantId}:${date}`)
+    if (pending) return pending
+  }
+
+  const promise = getWeatherUncoalesced(params)
+  const key = `${exploitantId}:${date}`
+  inFlight.set(key, promise)
+  try {
+    return await promise
+  } finally {
+    inFlight.delete(key)
+  }
+}
+
+async function getWeatherUncoalesced(params: GetWeatherParams): Promise<WeatherForecast> {
   const { exploitantId, latitude, longitude, date, forceRefresh } = params
 
   try {


### PR DESCRIPTION
## Summary

Traite **#43** — dedupe les appels concurrents à `getWeather()` sur une même clé `(exploitantId, date)`.

## Analyse préalable

Le DB cache (`weatherCache`) est déjà en place avec un TTL de 30 min. La fenêtre de risque est **uniquement** sur un cache miss avec N appelants concurrents — chacun court-circuite le cache en même temps et fan-out vers Open-Meteo.

## Solution

`Map<key, Promise<WeatherForecast>>` en mémoire dans `lib/weather/cache.ts` :

- Avant de démarrer la chaîne cache-check → API → upsert, check si une promise est déjà en vol pour `${exploitantId}:${date}`. Si oui → renvoyer la même promise.
- La promise est seed-ée avant le premier appel et **supprimée dans un `finally`** quand elle se résout (succès ou échec).
- `forceRefresh` (bouton "rafraîchir météo" côté UI) bypass le dedupe — comportement user-initiated inchangé.

## Ce qui n'est **pas** fait

- **Pas de coordination cross-instance** : ça demanderait Redis (pas dans la stack aujourd'hui). Sur Vercel serverless, chaque invocation a sa propre Map. Le DB cache 30 min couvre les visites répétées entre instances.
- **Pas de rate-limit dur** (N calls/min/exploitant) : le dedupe + DB cache sont largement suffisants pour le trafic actuel. On ouvrira un ticket dédié si jamais on voit des pics anormaux dans les logs d'audit (merci #41).

## Closes

Closes #43.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests passent
- [ ] Vercel preview : vider le cache météo en base, recharger le dashboard sur 3 onglets simultanément → vérifier dans les logs qu'une seule requête Open-Meteo part
- [ ] Smoke : bouton "rafraîchir météo" sur `/vols/[id]` → doit toujours forcer un vrai fetch

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32