### PR TITLE
ux(#48): Suspense + skeleton around FlightCard weather strip

### DIFF
--- a/components/cockpit/weather-strip-skeleton.tsx
+++ b/components/cockpit/weather-strip-skeleton.tsx
@@ -1,0 +1,31 @@
+import { MonoLabel } from '@/components/cockpit/mono-label'
+
+/**
+ * Placeholder for the `FlightCard` weather strip — same height and padding
+ * as the real strip, with shimmer-style blocks where the wind / temp /
+ * go-nogo chips will land once the forecast resolves. Paired with a
+ * `<Suspense>` boundary around the strip so async weather fetchers
+ * (`use(weatherPromise)`) don't cause a whole-card flash.
+ */
+export function WeatherStripSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Chargement de la météo"
+      className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md bg-sky-50 px-3 py-2 text-sm"
+    >
+      <MonoLabel>
+        <span className="inline-block h-2 w-20 animate-pulse rounded bg-sky-200" />
+      </MonoLabel>
+      <div className="flex items-center gap-1.5">
+        <span className="inline-block h-4 w-4 animate-pulse rounded-full bg-sky-200" />
+        <span className="inline-block h-2 w-10 animate-pulse rounded bg-sky-200" />
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="inline-block h-3.5 w-3.5 animate-pulse rounded bg-sky-200" />
+        <span className="inline-block h-2 w-8 animate-pulse rounded bg-sky-200" />
+      </div>
+      <span className="ml-auto inline-block h-4 w-10 animate-pulse rounded bg-sky-200" />
+    </div>
+  )
+}

--- a/components/flight-card.tsx
+++ b/components/flight-card.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { AlertTriangle, Thermometer } from 'lucide-react'
@@ -8,6 +9,7 @@ import { LoadBar } from '@/components/cockpit/load-bar'
 import { MonoValue } from '@/components/cockpit/mono-value'
 import { WindArrow } from '@/components/cockpit/wind-arrow'
 import { MonoLabel } from '@/components/cockpit/mono-label'
+import { WeatherStripSkeleton } from '@/components/cockpit/weather-strip-skeleton'
 import { cn } from '@/lib/utils'
 import type { UserRole } from '@/lib/context'
 import type { FlightCardData, FlightCardWeather, MassBudget } from '@/lib/vol/flight-card-types'
@@ -159,30 +161,19 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
         <div className="text-xs italic text-sky-400">{t('massUnavailable')}</div>
       )}
 
-      {/* Weather strip */}
+      {/* Weather strip — wrapped in Suspense so a descendant can `use()` a
+          weather promise and fall back to the skeleton. Today `flight.weather`
+          is pre-computed server-side, so the boundary is a no-op; it stays
+          here for when the dashboard moves weather fetching into a streaming
+          boundary (see #48 follow-up). */}
       {flight.weather && (
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md bg-sky-50 px-3 py-2 text-sm">
-          <MonoLabel>
-            {tv(`creneau.${flight.creneau}`)} · {flight.weather.creneauRange}
-          </MonoLabel>
-          <div className="flex items-center gap-1.5 text-sky-700">
-            <WindArrow
-              direction={0}
-              speed={flight.weather.maxWindKt}
-              size={16}
-              className="text-sky-500"
-            />
-            <MonoValue value={flight.weather.maxWindKt} unit="kt" size={12} />
-            <span className="text-[10px] text-sky-400">({flight.weather.maxWindAltitude})</span>
-          </div>
-          <div className="flex items-center gap-1 text-sky-700">
-            <Thermometer className="h-3.5 w-3.5 text-sky-500" aria-hidden />
-            <MonoValue value={flight.weather.avgTemperature} unit="°C" size={12} />
-          </div>
-          <Chip tone={GONOGO_CHIP[flight.weather.goNogo]} size="sm" className="ml-auto">
-            {t(`goNogo.${flight.weather.goNogo}`)}
-          </Chip>
-        </div>
+        <Suspense fallback={<WeatherStripSkeleton />}>
+          <WeatherStrip
+            weather={flight.weather}
+            creneauLabel={tv(`creneau.${flight.creneau}`)}
+            goNogoLabel={t(`goNogo.${flight.weather.goNogo}`)}
+          />
+        </Suspense>
       )}
 
       {/* Actions */}
@@ -207,6 +198,36 @@ function MetaField({ label, value }: { label: string; value: string }) {
     <div className="space-y-0.5 min-w-0">
       <MonoLabel as="div">{label}</MonoLabel>
       <div className="truncate font-medium text-sky-900">{value}</div>
+    </div>
+  )
+}
+
+function WeatherStrip({
+  weather,
+  creneauLabel,
+  goNogoLabel,
+}: {
+  weather: FlightCardWeather
+  creneauLabel: string
+  goNogoLabel: string
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md bg-sky-50 px-3 py-2 text-sm">
+      <MonoLabel>
+        {creneauLabel} · {weather.creneauRange}
+      </MonoLabel>
+      <div className="flex items-center gap-1.5 text-sky-700">
+        <WindArrow direction={0} speed={weather.maxWindKt} size={16} className="text-sky-500" />
+        <MonoValue value={weather.maxWindKt} unit="kt" size={12} />
+        <span className="text-[10px] text-sky-400">({weather.maxWindAltitude})</span>
+      </div>
+      <div className="flex items-center gap-1 text-sky-700">
+        <Thermometer className="h-3.5 w-3.5 text-sky-500" aria-hidden />
+        <MonoValue value={weather.avgTemperature} unit="°C" size={12} />
+      </div>
+      <Chip tone={GONOGO_CHIP[weather.goNogo]} size="sm" className="ml-auto">
+        {goNogoLabel}
+      </Chip>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Traite **#48** — pose la Suspense boundary et son skeleton autour du strip météo de `FlightCard` pour préparer la migration vers du streaming / fetch côté client.

## Changements

### Nouveau composant

`components/cockpit/weather-strip-skeleton.tsx` — placeholder `animate-pulse` qui reprend la rythmique (padding, bg sky-50, gap) du strip météo réel. Barres squelette pour le créneau, la flèche de vent + la lecture kt, le thermomètre + la température, et le chip GO/NOGO.

### `FlightCard`

- Extraction de la JSX inline du strip météo en sous-composant `WeatherStrip` (dédié, typé sur `FlightCardWeather`) placé juste après `MetaField` en bas du fichier
- Wrap de `<WeatherStrip />` dans `<Suspense fallback={<WeatherStripSkeleton />}>`

## Pourquoi ça ne change rien aujourd'hui

`flight.weather` est encore calculé server-side en amont (dashboard + vols list), donc `WeatherStrip` reçoit une valeur résolue — la Suspense boundary est un no-op.

**La valeur ajoutée est prospective** : le jour où on déplace le fetch météo dans une async sous-composante qui `use()` une `Promise<FlightCardWeather>` (streaming, ou client component), le skeleton apparaît automatiquement sans faire flasher toute la carte.

## Closes

Closes #48.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : rien ne doit changer visuellement (FlightCard idem avec météo résolue, sans météo → pas de strip)
- [ ] Pour voir le skeleton en action : forcer un `await new Promise(r => setTimeout(r, 2000))` dans `WeatherStrip` temporairement et vérifier l'apparition du skeleton

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32