### PR TITLE
tests(#19): Playwright RBAC coverage for protected routes

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -113,6 +113,48 @@ export async function ensureSeedData(): Promise<void> {
         },
       })
     }
+
+    // PILOTE + EQUIPIER users in Cameron Balloons (needed for RBAC E2E coverage).
+    // Only the user rows and credential accounts are seeded — the associated
+    // Pilote/Equipier entities aren't required for route-access tests.
+    const extraUsers = [
+      {
+        email: 'pilote@cameronfrance.com',
+        name: 'Pilote Test',
+        role: 'PILOTE' as const,
+      },
+      {
+        email: 'equipier@cameronfrance.com',
+        name: 'Equipier Test',
+        role: 'EQUIPIER' as const,
+      },
+    ]
+
+    for (const u of extraUsers) {
+      const user = await prisma.user.upsert({
+        where: { email: u.email },
+        update: {},
+        create: {
+          email: u.email,
+          name: u.name,
+          role: u.role,
+          exploitantId: cameronBalloons.id,
+        },
+      })
+      const existing = await prisma.account.findFirst({
+        where: { userId: user.id, providerId: 'credential' },
+      })
+      if (!existing) {
+        await prisma.account.create({
+          data: {
+            userId: user.id,
+            accountId: user.id,
+            providerId: 'credential',
+            password: hashedPw,
+          },
+        })
+      }
+    }
   } finally {
     await prisma.$disconnect()
   }

--- a/tests/e2e/rbac.spec.ts
+++ b/tests/e2e/rbac.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * RBAC coverage — verifies server-side role guards on protected routes and
+ * the Cache-Control no-store header on PII-serving pages.
+ *
+ * Each role signs in once (serial describe block) and iterates through its
+ * restricted routes, asserting the `Accès refusé` screen rendered by
+ * `lib/errors.ts::ForbiddenError` → `app/[locale]/(app)/error.tsx`.
+ *
+ * Seed:
+ *  - olivier@cameronfrance.com (GERANT)
+ *  - dcuenot@calpax.fr (ADMIN_CALPAX)
+ *  - pilote@cameronfrance.com (PILOTE)
+ *  - equipier@cameronfrance.com (EQUIPIER)
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { ensureSeedData } from './helpers'
+
+const PASSWORD = process.env.SEED_DEFAULT_PASSWORD ?? 'Calpax-2026-Demo!'
+
+/** Routes gated by `requireRole('ADMIN_CALPAX', 'GERANT')`. */
+const ADMIN_GERANT_ONLY = ['/fr/settings', '/fr/rgpd', '/fr/audit']
+/** Routes gated by `requireRole('ADMIN_CALPAX', 'GERANT', 'PILOTE')`. */
+const NO_EQUIPIER = ['/fr/equipiers', '/fr/vehicules', '/fr/sites']
+
+async function signIn(page: Page, email: string): Promise<void> {
+  await page.goto('/fr/auth/signin')
+  await page.getByRole('textbox', { name: /email/i }).fill(email)
+  await page.locator('input[name="password"]').fill(PASSWORD)
+  await page.getByRole('button', { name: /cockpit|se connecter|sign in/i }).click()
+  // After sign-in the user lands on /fr (dashboard)
+  await page.waitForURL(/\/fr\/?$/, { timeout: 20_000 })
+}
+
+async function expectForbidden(page: Page, route: string): Promise<void> {
+  await page.goto(route)
+  await expect(
+    page.getByRole('heading', { name: /accès refusé|access denied/i }),
+    `expected forbidden screen on ${route}`,
+  ).toBeVisible({ timeout: 10_000 })
+}
+
+test.beforeAll(async () => {
+  await ensureSeedData()
+})
+
+test.describe.serial('RBAC — EQUIPIER', () => {
+  test('is forbidden on admin/gerant routes', async ({ page }) => {
+    await signIn(page, 'equipier@cameronfrance.com')
+    for (const route of [...ADMIN_GERANT_ONLY, ...NO_EQUIPIER]) {
+      await expectForbidden(page, route)
+    }
+  })
+
+  test('hitting a billet detail URL directly returns forbidden', async ({ page }) => {
+    // We don't need a real billet id — requireRole runs before the db lookup.
+    await expectForbidden(page, '/fr/billets/fake-billet-id')
+  })
+})
+
+test.describe.serial('RBAC — PILOTE', () => {
+  test('is forbidden on admin-only routes', async ({ page }) => {
+    await signIn(page, 'pilote@cameronfrance.com')
+    for (const route of ADMIN_GERANT_ONLY) {
+      await expectForbidden(page, route)
+    }
+  })
+
+  test('hitting a billet detail URL directly returns forbidden', async ({ page }) => {
+    await expectForbidden(page, '/fr/billets/fake-billet-id')
+  })
+})
+
+test('Cache-Control: no-store on protected app routes', async ({ page }) => {
+  await signIn(page, 'olivier@cameronfrance.com')
+  const response = await page.goto('/fr')
+  expect(response, 'expected a response for the dashboard').not.toBeNull()
+  expect(response!.headers()['cache-control']).toContain('no-store')
+})


### PR DESCRIPTION
## Summary

Traite **#19** — ajoute une couverture E2E des garde-rôles serveur sur les routes protégées. On a touché le role-gating pas mal ces derniers PRs (refonte + RGPD #42), c'est le moment de poser le filet.

## Ce qui est testé

### `tests/e2e/rbac.spec.ts`

Deux `describe.serial` (un par rôle) qui :
- signent l'utilisateur via l'UI une fois
- itèrent sur les routes restreintes
- vérifient l'écran « Accès refusé » rendu par `app/[locale]/(app)/error.tsx` quand `requireRole` throw `ForbiddenError`

**EQUIPIER** → bloqué sur :
- `/fr/settings`, `/fr/rgpd`, `/fr/audit` *(ADMIN/GERANT uniquement)*
- `/fr/equipiers`, `/fr/vehicules`, `/fr/sites` *(pas pour EQUIPIER)*
- `/fr/billets/<id>` *(direct URL hit, gate ajouté dans PR #53)*

**PILOTE** → bloqué sur :
- `/fr/settings`, `/fr/rgpd`, `/fr/audit`
- `/fr/billets/<id>`

### Test Cache-Control séparé

Sign-in GERANT → GET `/fr` → assert `Cache-Control: private, no-store` (header posé dans `middleware.ts` par PR #53).

## Seed étendu (`tests/e2e/helpers.ts`)

`ensureSeedData()` provisionne maintenant :
- `pilote@cameronfrance.com` (role `PILOTE`)
- `equipier@cameronfrance.com` (role `EQUIPIER`)

Sous Cameron Balloons, chacun avec un credential account. Pas d'entités `Pilote`/`Equipier` associées — pas nécessaires pour les assertions de route access.

## Closes

Closes #19.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests unit/integration
- [ ] Local : `pnpm playwright test rbac.spec.ts` contre un dev server + DB seedée
- [ ] CI : vérifier que la suite Playwright E2E passe avec les nouveaux tests

## Limites connues

- Ne teste **pas** la RGPD gate visuelle sur la colonne poids passager (vol detail) — ça demande de seeder un vol + passagers avec poids chiffré. Follow-up potentiel.
- Ne teste pas l'accès aux entités filtrées par tenant (déjà couvert dans `tests/integration/tenant-isolation.spec.ts`).

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32