### PR TITLE
td(#11): migrate Paiement.montantTtc from Float to Decimal(10,2)

### DIFF
--- a/prisma/migrations/20260422093700_paiement_montant_decimal/migration.sql
+++ b/prisma/migrations/20260422093700_paiement_montant_decimal/migration.sql
@@ -1,0 +1,7 @@
+-- Migrate `paiement.montantTtc` from DOUBLE PRECISION (Float) to NUMERIC(10, 2)
+-- to match `billet.montantTtc` and remove any rounding drift before the
+-- Mollie payment reconciliation work. Existing Float values (2-decimal EUR
+-- amounts under 10M) cast losslessly.
+
+ALTER TABLE "paiement"
+  ALTER COLUMN "montantTtc" SET DATA TYPE DECIMAL(10, 2) USING "montantTtc"::DECIMAL(10, 2);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -394,7 +394,7 @@ model Paiement {
   billet           Billet       @relation(fields: [billetId], references: [id], onDelete: Cascade)
 
   modePaiement     ModePaiement
-  montantTtc       Float
+  montantTtc       Decimal      @db.Decimal(10, 2)
   datePaiement     DateTime
   dateEncaissement DateTime?
   commentaire      String?


### PR DESCRIPTION
## Summary

Traite **#11** — aligne `Paiement.montantTtc` sur le type `Decimal(10,2)` déjà utilisé pour `Billet.montantTtc`. Prérequis propre pour la réconciliation Mollie qui s'appuie sur des montants exacts.

## Scope réduit par rapport à l'issue

L'issue disait "Paiement **and** Billet models store montantTtc as Prisma Float" — en fait `Billet.montantTtc` est déjà en `Decimal @db.Decimal(10, 2)` depuis longtemps. Seul `Paiement.montantTtc` restait en `Float`. Donc changement d'une colonne.

## Schema

```diff
  modePaiement     ModePaiement
- montantTtc       Float
+ montantTtc       Decimal       @db.Decimal(10, 2)
  datePaiement     DateTime
```

## Migration

`prisma/migrations/20260422093700_paiement_montant_decimal/migration.sql` :

```sql
ALTER TABLE "paiement"
  ALTER COLUMN "montantTtc" SET DATA TYPE DECIMAL(10, 2) USING "montantTtc"::DECIMAL(10, 2);
```

Les valeurs Float64 à 2 décimales en EUR < 10M se castent sans perte → **pas de backfill** nécessaire.

## Call sites — zéro changement

Toute l'arithmétique passe déjà par `Number(p.montantTtc)` :

| Fichier | Usage |
|---|---|
| `app/[locale]/(app)/billets/[id]/page.tsx` | `sum + Number(p.montantTtc)`, solde restant |
| `app/[locale]/(app)/billets/[id]/page.tsx` | `formatEuros(Number(paiement.montantTtc))` |
| `lib/actions/paiement.ts` | `Number(billet.montantTtc)`, `paiements.map(p => Number(p.montantTtc))` |
| `lib/actions/rgpd.ts` | export JSON (sérialisé identique qu'avant via Prisma.Decimal.toJSON → string) |

`z.coerce.number()` sur `lib/schemas/paiement.ts` reste valide — Prisma convertit `number → Decimal` sur insert.

## Closes

Closes #11.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Appliquer la migration en preview Vercel / staging : `pnpm prisma migrate deploy`
- [ ] Smoke : créer un paiement via `/billets/[id]` → vérifier montant stocké correctement + solde calculé
- [ ] RGPD export : re-vérifier le JSON sortant (les montants sont déjà des strings via Prisma Decimal, pas de regression)

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32