### PR TITLE
security: defense-in-depth on admin audit + RBAC sidebar default (#28 #34 #35)

### DIFF
--- a/app/[locale]/admin/audit/page.tsx
+++ b/app/[locale]/admin/audit/page.tsx
@@ -1,25 +1,34 @@
 import { getTranslations } from 'next-intl/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireRole } from '@/lib/auth/requireRole'
 import { basePrisma } from '@/lib/db/base'
 import { AdminAuditClient } from './audit-client'
 
 export default async function AdminAuditPage() {
-  const t = await getTranslations('admin.audit')
+  return requireAuth(async () => {
+    // Defense-in-depth: admin/layout.tsx already gates this route, but the
+    // page itself queries the cross-tenant audit log via basePrisma so we
+    // add an explicit guard here too (cf. issue #28).
+    requireRole('ADMIN_CALPAX')
 
-  const [exploitants, admins] = await Promise.all([
-    basePrisma.exploitant.findMany({
-      select: { id: true, name: true },
-      orderBy: { name: 'asc' },
-    }),
-    basePrisma.user.findMany({
-      where: { role: 'ADMIN_CALPAX' },
-      select: { id: true, name: true, email: true },
-    }),
-  ])
+    const t = await getTranslations('admin.audit')
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-3xl font-bold tracking-tight">{t('title')}</h1>
-      <AdminAuditClient exploitants={exploitants} admins={admins} />
-    </div>
-  )
+    const [exploitants, admins] = await Promise.all([
+      basePrisma.exploitant.findMany({
+        select: { id: true, name: true },
+        orderBy: { name: 'asc' },
+      }),
+      basePrisma.user.findMany({
+        where: { role: 'ADMIN_CALPAX' },
+        select: { id: true, name: true, email: true },
+      }),
+    ])
+
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">{t('title')}</h1>
+        <AdminAuditClient exploitants={exploitants} admins={admins} />
+      </div>
+    )
+  })
 }

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -114,7 +114,12 @@ export function AppSidebar({
     },
   ]
 
-  const role = (userRole as UserRole) ?? 'GERANT'
+  // Least-privilege default: if the session somehow lacks a role, hide
+  // everything except the EQUIPIER-visible items. Server-side enforcement
+  // is the real line of defense (requireRole in each page / action), but
+  // the sidebar shouldn't advertise items the user can't reach
+  // (cf. issue #35 — fail-open audit).
+  const role = (userRole as UserRole) ?? 'EQUIPIER'
   const filteredGroups = groups
     .map((group) => ({
       ...group,

--- a/lib/actions/audit.ts
+++ b/lib/actions/audit.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireRole } from '@/lib/auth/requireRole'
 import { db } from '@/lib/db'
 
 type AuditFilters = {
@@ -11,6 +12,12 @@ type AuditFilters = {
 
 export async function fetchAuditLogs(filters: AuditFilters) {
   return requireAuth(async () => {
+    // The tenant-scoped audit viewer is rendered from
+    // `app/[locale]/(app)/audit/page.tsx` which gates by role, but we
+    // duplicate the check here so a direct action POST from a PILOTE /
+    // EQUIPIER still returns ForbiddenError (cf. issue #34).
+    requireRole('ADMIN_CALPAX', 'GERANT')
+
     const page = filters.page ?? 1
     const take = 50
     const skip = (page - 1) * take


### PR DESCRIPTION
## Summary

3 petits passes de durcissement RBAC alignés autour de la défense en profondeur.

## #28 — page admin/audit

`app/[locale]/admin/audit/page.tsx` wrappée dans `requireAuth` + `requireRole('ADMIN_CALPAX')`. Avant, la page lançait `basePrisma.exploitant.findMany()` et `user.findMany({ role: ADMIN_CALPAX })` en se fiant **uniquement** au garde du `admin/layout.tsx`. Un futur refactor qui bypasserait le layout (route parallèle, redirect conditionnel) aurait silencieusement exposé la liste complète des exploitants et des admins.

## #34 — action server audit

`lib/actions/audit.ts::fetchAuditLogs` → `requireRole('ADMIN_CALPAX', 'GERANT')` ajouté dans le `requireAuth`. Avant, un `POST` direct depuis un client PILOTE/EQUIPIER contournait le garde de la page et récupérait les audit logs du tenant.

Audit complet de `lib/actions/admin.ts` : les 4 actions exportées ont déjà `requireRole('ADMIN_CALPAX')` dans leur `requireAuth` — rien à ajouter là.

## #35 — sidebar default role

`components/app-sidebar.tsx` : `(userRole as UserRole) ?? 'GERANT'` → `?? 'EQUIPIER'`. Sans claim de rôle, la sidebar proposait tous les items GERANT (billets / settings / rgpd / audit) — fail-open UI-level. L'enforcement serveur reste la vraie ligne de défense ; on arrête juste d'annoncer des items hors de portée.

Grep de `CAN_*.includes(role)` : seul `flight-card.tsx` utilise le pattern, et il a déjà son null-guard `!!userRole && …` depuis PR #24. Rien d'autre à fixer.

## Hors scope

`lib/auth/requireAuth.ts` (issue **#27**) fallback toujours sur GERANT côté serveur. Le flip vers EQUIPIER nécessite un audit DB préalable (users avec role null doivent être backfillés) — à faire séparément.

## Closes

Closes #28, #34, #35.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : tenter un `POST` direct sur `fetchAuditLogs` en étant PILOTE → doit retourner ForbiddenError

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32