### PR TITLE
cleanup: rename maxWindKt → maxWindKmh + PasswordInput in settings (#26 #29)

### DIFF
--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -141,7 +141,7 @@ export default async function HomePage({ params }: Props) {
       if (hours.length === 0) return null
       const summary = summarizeWeather(hours, seuilVent)
       return {
-        maxWindKt: summary.maxWindKt,
+        maxWindKmh: summary.maxWindKmh,
         maxWindAltitude: summary.maxWindAltitude,
         avgTemperature: summary.avgTemperature,
         goNogo: levelToGoNogo(summary.level),
@@ -282,8 +282,8 @@ export default async function HomePage({ params }: Props) {
 
     // 6. Derive cockpit KPIs from today's data
     const nextFlight = cards[0] ?? null
-    const maxWindKt = cards.reduce(
-      (max, c) => (c.weather && c.weather.maxWindKt > max ? c.weather.maxWindKt : max),
+    const maxWindKmh = cards.reduce(
+      (max, c) => (c.weather && c.weather.maxWindKmh > max ? c.weather.maxWindKmh : max),
       0,
     )
     const paxBooked = cards.reduce((sum, c) => sum + c.passagerCount, 0)
@@ -320,10 +320,10 @@ export default async function HomePage({ params }: Props) {
           />
           <KpiTile
             label={t('kpi.wind')}
-            value={maxWindKt > 0 ? `${maxWindKt}` : t('kpi.windEmpty')}
-            sub={maxWindKt > 0 ? t('kpi.windUnit') : null}
-            icon={maxWindKt > 0 ? <WindArrow speed={maxWindKt} size={16} /> : null}
-            tone={maxWindKt >= seuilVent ? 'warn' : 'default'}
+            value={maxWindKmh > 0 ? `${maxWindKmh}` : t('kpi.windEmpty')}
+            sub={maxWindKmh > 0 ? t('kpi.windUnit') : null}
+            icon={maxWindKmh > 0 ? <WindArrow speed={maxWindKmh} size={16} /> : null}
+            tone={maxWindKmh >= seuilVent ? 'warn' : 'default'}
           />
           <KpiTile
             label={t('kpi.pax')}

--- a/app/api/cron/meteo-alert/route.ts
+++ b/app/api/cron/meteo-alert/route.ts
@@ -136,7 +136,7 @@ export async function GET(request: Request): Promise<Response> {
           data: { meteoAlert: true },
         })
         logger.info(
-          { volId: vol.id, ballon: vol.ballon.nom, maxWind: summary.maxWindKt, threshold },
+          { volId: vol.id, ballon: vol.ballon.nom, maxWind: summary.maxWindKmh, threshold },
           '[meteo-alert] Vol flagged',
         )
         flagged++
@@ -146,7 +146,7 @@ export async function GET(request: Request): Promise<Response> {
           data: { meteoAlert: false },
         })
         logger.info(
-          { volId: vol.id, ballon: vol.ballon.nom, maxWind: summary.maxWindKt, threshold },
+          { volId: vol.id, ballon: vol.ballon.nom, maxWind: summary.maxWindKmh, threshold },
           '[meteo-alert] Vol cleared',
         )
         cleared++

--- a/components/change-password-form.tsx
+++ b/components/change-password-form.tsx
@@ -5,10 +5,10 @@ import { useTranslations } from 'next-intl'
 import { authClient } from '@/lib/auth-client'
 import { toast } from 'sonner'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Loader2 } from 'lucide-react'
+import { PasswordInput } from '@/components/auth/password-input'
 import { PasswordStrength } from '@/components/password-strength'
 import { formLabelClass } from '@/lib/ui'
 
@@ -54,30 +54,22 @@ export function ChangePasswordForm() {
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1.5">
-            <Label
-              htmlFor="current-password"
-              className={formLabelClass}
-            >
+            <Label htmlFor="current-password" className={formLabelClass}>
               {t('currentPassword')}
             </Label>
-            <Input
+            <PasswordInput
               id="current-password"
-              type="password"
               required
               value={currentPassword}
               onChange={(e) => setCurrentPassword(e.target.value)}
             />
           </div>
           <div className="space-y-1.5">
-            <Label
-              htmlFor="new-password"
-              className={formLabelClass}
-            >
+            <Label htmlFor="new-password" className={formLabelClass}>
               {t('newPassword')}
             </Label>
-            <Input
+            <PasswordInput
               id="new-password"
-              type="password"
               required
               minLength={12}
               value={newPassword}
@@ -86,15 +78,11 @@ export function ChangePasswordForm() {
             <PasswordStrength password={newPassword} minLength={12} />
           </div>
           <div className="space-y-1.5">
-            <Label
-              htmlFor="confirm-password"
-              className={formLabelClass}
-            >
+            <Label htmlFor="confirm-password" className={formLabelClass}>
               {t('confirmPassword')}
             </Label>
-            <Input
+            <PasswordInput
               id="confirm-password"
-              type="password"
               required
               minLength={12}
               value={confirmPassword}

--- a/components/cockpit/go-nogo-window.tsx
+++ b/components/cockpit/go-nogo-window.tsx
@@ -12,9 +12,9 @@ const LEVEL_STYLES: Record<WindowLevel, string> = {
   NOGO: 'bg-red-50 text-[color:var(--destructive)]',
 }
 
-function hourLevel(windKt: number, seuilVent: number): WindowLevel {
-  if (windKt >= seuilVent) return 'NOGO'
-  if (windKt >= seuilVent * 0.75) return 'HOLD'
+function hourLevel(windKmh: number, seuilVent: number): WindowLevel {
+  if (windKmh >= seuilVent) return 'NOGO'
+  if (windKmh >= seuilVent * 0.75) return 'HOLD'
   return 'GO'
 }
 

--- a/components/flight-card.tsx
+++ b/components/flight-card.tsx
@@ -217,8 +217,8 @@ function WeatherStrip({
         {creneauLabel} · {weather.creneauRange}
       </MonoLabel>
       <div className="flex items-center gap-1.5 text-sky-700">
-        <WindArrow direction={0} speed={weather.maxWindKt} size={16} className="text-sky-500" />
-        <MonoValue value={weather.maxWindKt} unit="kt" size={12} />
+        <WindArrow direction={0} speed={weather.maxWindKmh} size={16} className="text-sky-500" />
+        <MonoValue value={weather.maxWindKmh} unit="km/h" size={12} />
         <span className="text-[10px] text-sky-400">({weather.maxWindAltitude})</span>
       </div>
       <div className="flex items-center gap-1 text-sky-700">

--- a/components/weather-table.tsx
+++ b/components/weather-table.tsx
@@ -91,7 +91,7 @@ export async function WeatherTable({ hours, summary, seuilVent }: Props) {
         <div>
           <span className="font-semibold text-base">{t(`level.${summary.level}`)}</span>
           <span className="ml-3 text-sm">
-            {t('maxWind')}: {summary.maxWindKt} km/h ({summary.maxWindAltitude})
+            {t('maxWind')}: {summary.maxWindKmh} km/h ({summary.maxWindAltitude})
           </span>
         </div>
         <div className="text-sm">

--- a/lib/pdf/fiche-vol.tsx
+++ b/lib/pdf/fiche-vol.tsx
@@ -67,7 +67,7 @@ export type FicheVolData = {
       precipitationProb: number
     }[]
     summary: {
-      maxWindKt: number
+      maxWindKmh: number
       maxWindAltitude: string
       level: string
       avgTemperature: number
@@ -657,7 +657,7 @@ function Page3({ data }: { data: FicheVolData }) {
             </Text>
             <View style={styles.meteoBannerRow}>
               <Text style={styles.meteoBannerMeta}>
-                Vent max: {meteo.summary.maxWindKt} km/h ({meteo.summary.maxWindAltitude}) | OAT
+                Vent max: {meteo.summary.maxWindKmh} km/h ({meteo.summary.maxWindAltitude}) | OAT
                 moy: {meteo.summary.avgTemperature}°C
               </Text>
               <Text style={styles.meteoBannerLevel}>{meteo.summary.level}</Text>

--- a/lib/vol/flight-card-types.ts
+++ b/lib/vol/flight-card-types.ts
@@ -9,7 +9,7 @@ export type MassBudget = {
 }
 
 export type FlightCardWeather = {
-  maxWindKt: number
+  maxWindKmh: number
   maxWindAltitude: string
   avgTemperature: number
   goNogo: 'GO' | 'NOGO' | 'MARGINAL'

--- a/lib/weather/classify.ts
+++ b/lib/weather/classify.ts
@@ -1,16 +1,19 @@
 import type { HourlyWeather, WindLevel, WeatherSummary } from './types'
 
-export function classifyWind(speedKt: number, seuilKt: number): WindLevel {
-  if (speedKt > seuilKt + 5) return 'DANGER'
-  if (speedKt >= seuilKt) return 'WARNING'
+export function classifyWind(speedKmh: number, seuilKmh: number): WindLevel {
+  if (speedKmh > seuilKmh + 5) return 'DANGER'
+  if (speedKmh >= seuilKmh) return 'WARNING'
   return 'OK'
 }
 
 const ALTITUDES = ['10m', '80m', '120m', '180m'] as const
 const ALTITUDE_KEYS = ['wind10m', 'wind80m', 'wind120m', 'wind180m'] as const
 
-export function summarizeWeather(hours: readonly HourlyWeather[], seuilKt: number): WeatherSummary {
-  let maxWindKt = 0
+export function summarizeWeather(
+  hours: readonly HourlyWeather[],
+  seuilKmh: number,
+): WeatherSummary {
+  let maxWindKmh = 0
   let maxWindAltitude = '10m'
 
   for (const hour of hours) {
@@ -18,8 +21,8 @@ export function summarizeWeather(hours: readonly HourlyWeather[], seuilKt: numbe
       const key = ALTITUDE_KEYS[i]!
       const alt = ALTITUDES[i]!
       const wind = hour[key]
-      if (wind.speed > maxWindKt) {
-        maxWindKt = wind.speed
+      if (wind.speed > maxWindKmh) {
+        maxWindKmh = wind.speed
         maxWindAltitude = alt
       }
     }
@@ -31,9 +34,9 @@ export function summarizeWeather(hours: readonly HourlyWeather[], seuilKt: numbe
       : 0
 
   return {
-    maxWindKt,
+    maxWindKmh,
     maxWindAltitude,
-    level: classifyWind(maxWindKt, seuilKt),
+    level: classifyWind(maxWindKmh, seuilKmh),
     avgTemperature,
   }
 }

--- a/lib/weather/types.ts
+++ b/lib/weather/types.ts
@@ -22,7 +22,7 @@ export type WeatherForecast = {
 export type WindLevel = 'OK' | 'WARNING' | 'DANGER'
 
 export type WeatherSummary = {
-  maxWindKt: number
+  maxWindKmh: number
   maxWindAltitude: string
   level: WindLevel
   avgTemperature: number

--- a/messages/en.json
+++ b/messages/en.json
@@ -727,7 +727,7 @@
       "nextFlightEmpty": "—",
       "wind": "MAX WIND",
       "windEmpty": "—",
-      "windUnit": "kt",
+      "windUnit": "km/h",
       "pax": "PAX",
       "paxCovered": "{booked}/{seats}",
       "flights": "FLIGHTS",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -731,7 +731,7 @@
       "nextFlightEmpty": "—",
       "wind": "VENT MAX",
       "windEmpty": "—",
-      "windUnit": "kt",
+      "windUnit": "km/h",
       "pax": "PAX",
       "paxCovered": "{booked}/{seats}",
       "flights": "VOLS",

--- a/tests/unit/weather-classify.spec.ts
+++ b/tests/unit/weather-classify.spec.ts
@@ -67,7 +67,7 @@ describe('summarizeWeather', () => {
       }),
     ]
     const result = summarizeWeather(hours, 15)
-    expect(result.maxWindKt).toBe(22)
+    expect(result.maxWindKmh).toBe(22)
     expect(result.maxWindAltitude).toBe('120m')
     expect(result.level).toBe('DANGER')
   })
@@ -91,9 +91,9 @@ describe('summarizeWeather', () => {
     expect(result.level).toBe('OK')
   })
 
-  it('handles empty hours array (maxWindKt=0, level=OK)', () => {
+  it('handles empty hours array (maxWindKmh=0, level=OK)', () => {
     const result = summarizeWeather([], 15)
-    expect(result.maxWindKt).toBe(0)
+    expect(result.maxWindKmh).toBe(0)
     expect(result.level).toBe('OK')
   })
 })


### PR DESCRIPTION
## Summary

Deux cleanups regroupés. Le troisième de la série (#30) s'est auto-résolu avec la refonte Phase 2 — fermé en parallèle avec note.

## #26 — rename `maxWindKt` → `maxWindKmh`

Open-Meteo est appelé avec `wind_speed_unit=kmh` donc tous les identifiants en `*Kt` étaient menteurs (UI affichait déjà "km/h" à certains endroits — confirmant la confusion).

Rename sweepé sur :

- `lib/weather/types.ts` / `classify.ts` — `maxWindKt`, `speedKt`, `seuilKt`
- `lib/vol/flight-card-types.ts` — `maxWindKt` sur `FlightCardWeather`
- `lib/pdf/fiche-vol.tsx` — type input
- `app/[locale]/(app)/page.tsx` — KPI dashboard
- `app/api/cron/meteo-alert/route.ts` — log payload
- `components/flight-card.tsx`, `weather-table.tsx` — read/display
- `components/cockpit/go-nogo-window.tsx` — param local
- `tests/unit/weather-classify.spec.ts` — assertions

+ fix du `<MonoValue unit="kt">` dans FlightCard → `"km/h"`
+ i18n `dashboard.kpi.windUnit` "kt" → "km/h" (fr + en)

## #29 — `PasswordInput` dans `change-password-form`

Les 3 champs (currentPassword, newPassword, confirmPassword) adoptent `@/components/auth/password-input`. Gagnent :

- Show/hide toggle avec touch target 44×44 (WCAG 2.5.5)
- Hooks `aria-invalid` / `aria-describedby`
- Parité visuelle avec signin / reset-password

Drop de l'import `Input` (inutilisé).

## #30 — fermé séparément

Le SVG balloon inline était dans l'ancien signin (~100 lignes). La refonte Phase 2 (PR #36) l'a remplacé par le gradient Editorial + TopoPattern + halo soleil. Il n'y a plus de SVG à extraire. Issue fermée avec note.

## Closes

Closes #26, #29.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : settings page → vérifier les 3 toggle show/hide ; dashboard → "VENT MAX 9 km/h"

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32