### PR TITLE
feat(#14): RGPD 5-year retention cron

### DIFF
--- a/app/api/cron/rgpd-retention/route.ts
+++ b/app/api/cron/rgpd-retention/route.ts
@@ -1,0 +1,112 @@
+import { AuditAction } from '@prisma/client'
+import { basePrisma } from '@/lib/db/base'
+import { writeAudit } from '@/lib/audit/write'
+import { logger } from '@/lib/logger'
+
+/**
+ * RGPD 5-year retention cron. Anonymises PII on Billets + Passagers whose
+ * `createdAt` is older than the cutoff so we comply with RGPD art. 5(1)(e)
+ * (limitation de la conservation) and CLAUDE.md's "5 ans maximum" contract.
+ *
+ * Runs weekly on Monday 06:00 UTC (see vercel.json). Idempotent — records
+ * already anonymised stay anonymised (replacement strings are the same).
+ *
+ * What's anonymised:
+ *  - Passager: prenom, nom, email, telephone, poidsEncrypted → scrubbed
+ *  - Billet: payeurCiv/Prenom/Nom/Email/Telephone/Adresse/Cp/Ville → scrubbed
+ *
+ * What's preserved for audit / financial records:
+ *  - Billet reference, checksum, statut, montantTtc, dates
+ *  - Passager structural link to billet + vol, age, pmr
+ *  - Payment history (Paiement rows — no PII beyond amounts/dates)
+ *
+ * Requires `Authorization: Bearer $CRON_SECRET`.
+ */
+export async function GET(request: Request): Promise<Response> {
+  const authHeader = request.headers.get('Authorization')
+  const cronSecret = process.env.CRON_SECRET
+
+  if (!cronSecret) {
+    logger.error('CRON_SECRET is not configured')
+    return Response.json({ error: 'Server misconfiguration' }, { status: 500 })
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    logger.warn('Unauthorized rgpd-retention cron request')
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const now = new Date()
+  const cutoff = new Date(now)
+  cutoff.setFullYear(cutoff.getFullYear() - 5)
+
+  // ── Passagers ──────────────────────────────────────────────────────────
+  const stalePassagers = await basePrisma.passager.findMany({
+    where: { createdAt: { lt: cutoff }, nom: { not: ANONYMIZED_NAME } },
+    select: { id: true, exploitantId: true },
+  })
+
+  for (const p of stalePassagers) {
+    await basePrisma.passager.update({
+      where: { id: p.id },
+      data: {
+        prenom: ANONYMIZED_FIRSTNAME,
+        nom: ANONYMIZED_NAME,
+        email: null,
+        telephone: null,
+        poidsEncrypted: null,
+      },
+    })
+    await writeAudit({
+      exploitantId: p.exploitantId,
+      entityType: 'Passager',
+      entityId: p.id,
+      action: AuditAction.UPDATE,
+      field: 'rgpd_retention_5y',
+      afterValue: { anonymizedAt: now.toISOString() },
+    })
+  }
+
+  // ── Billets ────────────────────────────────────────────────────────────
+  const staleBillets = await basePrisma.billet.findMany({
+    where: { createdAt: { lt: cutoff }, payeurNom: { not: ANONYMIZED_NAME } },
+    select: { id: true, exploitantId: true },
+  })
+
+  for (const b of staleBillets) {
+    await basePrisma.billet.update({
+      where: { id: b.id },
+      data: {
+        payeurCiv: null,
+        payeurPrenom: ANONYMIZED_FIRSTNAME,
+        payeurNom: ANONYMIZED_NAME,
+        payeurEmail: null,
+        payeurTelephone: null,
+        payeurAdresse: null,
+        payeurCp: null,
+        payeurVille: null,
+      },
+    })
+    await writeAudit({
+      exploitantId: b.exploitantId,
+      entityType: 'Billet',
+      entityId: b.id,
+      action: AuditAction.UPDATE,
+      field: 'rgpd_retention_5y',
+      afterValue: { anonymizedAt: now.toISOString() },
+    })
+  }
+
+  const summary = {
+    cutoff: cutoff.toISOString(),
+    passagersAnonymized: stalePassagers.length,
+    billetsAnonymized: staleBillets.length,
+  }
+
+  logger.info(summary, 'rgpd-retention cron completed')
+
+  return Response.json({ ok: true, ...summary })
+}
+
+const ANONYMIZED_FIRSTNAME = 'RGPD'
+const ANONYMIZED_NAME = 'ANONYMIZED'

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/meteo-alert",
       "schedule": "0 5 * * *"
+    },
+    {
+      "path": "/api/cron/rgpd-retention",
+      "schedule": "0 6 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Traite **#14** — met en conformité le contrat « 5 ans maximum, suppression automatique » posé dans CLAUDE.md et requis par RGPD art. 5(1)(e).

## Ce qui est fait

### Nouveau cron `app/api/cron/rgpd-retention/route.ts`

- Auth Bearer sur `CRON_SECRET` (même pattern que `digest`, `rappels`, `meteo-alert`)
- Calcule `cutoff = now − 5 ans`
- Scrube les **Passagers** avec `createdAt < cutoff` et non déjà anonymisés (guard idempotence via `nom != 'ANONYMIZED'`) :
  - `prenom`, `nom` → `"RGPD" / "ANONYMIZED"`
  - `email`, `telephone`, `poidsEncrypted` → `null`
- Scrube les **Billets** de la même façon :
  - `payeurCiv/Prenom/Nom/Email/Telephone/Adresse/Cp/Ville` → null ou placeholders

### Ce qui est préservé

- **Billet** : `reference`, `checksum`, `montantTtc`, `statut`, dates — nécessaires pour les registres financiers et la génération de stats anonymisées
- **Passager** : lien structurel `billetId`/`volId`, `age`, `pmr`
- **Paiement** : intouché — aucun PII au-delà du montant/date/mode

### Audit log

Une entrée `AuditLog` par anonymisation :
```
{ entityType: 'Passager' | 'Billet',
  action: UPDATE,
  field: 'rgpd_retention_5y',
  afterValue: { anonymizedAt: ... } }
```

### Schedule

`vercel.json` : nouveau cron `0 6 * * 1` — **lundi 06:00 UTC**, une heure avant le digest hebdo pour que la digest voie un dataset proprement purgé.

## Hors scope (peut venir plus tard)

- Email de notification à l'exploitant (l'audit log suffit côté super-admin)
- Vols anciens : un vol > 5 ans n'est pas supprimé aujourd'hui — il n'a aucun PII direct (passagers/billets liés couvrent ça)
- Purge irreversible (DELETE vs anonymisation) — on garde l'anonymisation pour préserver les refs financiers

## Closes

Closes #14.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Staging : appeler manuellement `curl -H "Authorization: Bearer $CRON_SECRET" /api/cron/rgpd-retention` avec des billets > 5 ans en DB → vérifier le JSON de retour + les audit rows
- [ ] Idempotence : relancer le cron → `passagersAnonymized=0, billetsAnonymized=0` (guard via `nom != 'ANONYMIZED'`)

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32