### PR TITLE
ux(#6): add sticky sections nav on billet form

### DIFF
--- a/app/[locale]/(app)/billets/[id]/edit/billet-form.tsx
+++ b/app/[locale]/(app)/billets/[id]/edit/billet-form.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { toast } from 'sonner'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { FormSectionsNav } from '@/components/form-sections-nav'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -106,8 +107,17 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
   const isNew = !billetId
   const backHref = isNew ? `/${locale}/billets` : `/${locale}/billets/${billetId}`
 
+  const sections = [
+    { id: 'billet-section-payeur', label: t('sections.payeur') },
+    { id: 'billet-section-planification', label: t('sections.planification') },
+    { id: 'billet-section-passagers', label: t('sections.passagers') },
+    { id: 'billet-section-bon-cadeau', label: t('sections.bonCadeau') },
+  ]
+
   return (
     <form action={handleSubmit} className="space-y-6">
+      <FormSectionsNav sections={sections} />
+
       {error && (
         <div className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
           {error}
@@ -115,9 +125,9 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
       )}
 
       {/* Section Payeur */}
-      <Card>
+      <Card id="billet-section-payeur" className="scroll-mt-24">
         <CardHeader>
-          <CardTitle className="text-base">Payeur</CardTitle>
+          <CardTitle className="text-base">{t('sections.payeur')}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-1">
@@ -234,9 +244,9 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
       <Separator />
 
       {/* Section Planification */}
-      <Card>
+      <Card id="billet-section-planification" className="scroll-mt-24">
         <CardHeader>
-          <CardTitle className="text-base">Planification</CardTitle>
+          <CardTitle className="text-base">{t('sections.planification')}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-1">
@@ -401,9 +411,9 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
       <Separator />
 
       {/* Section Passagers */}
-      <Card>
+      <Card id="billet-section-passagers" className="scroll-mt-24">
         <CardHeader>
-          <CardTitle className="text-base">Passagers</CardTitle>
+          <CardTitle className="text-base">{t('sections.passagers')}</CardTitle>
         </CardHeader>
         <CardContent className="overflow-x-auto">
           <PassagerTableEditor passagers={passagers} onChange={setPassagers} />
@@ -411,7 +421,7 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
       </Card>
 
       {/* Bon cadeau section */}
-      <Card>
+      <Card id="billet-section-bon-cadeau" className="scroll-mt-24">
         <CardHeader>
           <div className="flex items-center gap-3">
             <Switch id="estBonCadeau" checked={estBonCadeau} onCheckedChange={setEstBonCadeau} />

--- a/components/form-sections-nav.tsx
+++ b/components/form-sections-nav.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+type Section = {
+  id: string
+  label: string
+}
+
+type Props = {
+  sections: Section[]
+  className?: string
+}
+
+/**
+ * Sticky top navigation for long single-page forms with multiple Card
+ * sections (cf. issue #6). Shows "1 · Label" pills linked to `#id`
+ * anchors and highlights the section currently closest to the top of
+ * the viewport via IntersectionObserver.
+ *
+ * Drop-in: render just above the form and give each Card an `id`
+ * matching a section in the list.
+ */
+export function FormSectionsNav({ sections, className }: Props) {
+  const [activeId, setActiveId] = useState<string | null>(sections[0]?.id ?? null)
+
+  useEffect(() => {
+    if (sections.length === 0) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.find((e) => e.isIntersecting)
+        if (visible) setActiveId(visible.target.id)
+      },
+      { rootMargin: '-30% 0% -60% 0%', threshold: 0 },
+    )
+    for (const s of sections) {
+      const el = document.getElementById(s.id)
+      if (el) observer.observe(el)
+    }
+    return () => observer.disconnect()
+  }, [sections])
+
+  return (
+    <nav
+      aria-label="Form sections"
+      className={cn(
+        'sticky top-0 z-30 -mx-6 mb-2 flex gap-1 overflow-x-auto border-b border-sky-100 bg-card/95 px-6 py-2 backdrop-blur',
+        className,
+      )}
+    >
+      {sections.map((s, index) => (
+        <a
+          key={s.id}
+          href={`#${s.id}`}
+          aria-current={activeId === s.id ? 'step' : undefined}
+          className={cn(
+            'mono cap inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-[10px] transition-colors',
+            activeId === s.id
+              ? 'bg-dusk-100 text-dusk-700'
+              : 'text-sky-500 hover:bg-sky-50 hover:text-sky-700',
+          )}
+        >
+          <span className="font-semibold">{index + 1}</span>
+          <span className="opacity-40">·</span>
+          <span>{s.label}</span>
+        </a>
+      ))}
+    </nav>
+  )
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -391,6 +391,12 @@
   },
   "billets": {
     "title": "Flight tickets",
+    "sections": {
+      "payeur": "Payer",
+      "planification": "Scheduling",
+      "passagers": "Passengers",
+      "bonCadeau": "Gift voucher"
+    },
     "new": "New ticket",
     "backToList": "Back to list",
     "edit": "Edit",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -391,6 +391,12 @@
   },
   "billets": {
     "title": "Billets de vol",
+    "sections": {
+      "payeur": "Payeur",
+      "planification": "Planification",
+      "passagers": "Passagers",
+      "bonCadeau": "Bon cadeau"
+    },
     "new": "Nouveau billet",
     "backToList": "Retour à la liste",
     "edit": "Modifier",


### PR DESCRIPTION
## Summary

Traite **#6** — le billet form fait 4 cards Payeur / Planification / Passagers / Bon cadeau sur une seule page. Aucun repère visuel où on en est dans la saisie, surtout sur mobile / laptop 13".

## Ce qui est fait

### Nouveau composant `components/form-sections-nav.tsx`

- Barre sticky-top de pills mono caps : `1 · Payeur`, `2 · Planification`, `3 · Passagers`, `4 · Bon cadeau`
- Clic → anchor `#billet-section-*`
- Section active détectée via `IntersectionObserver` (rootMargin `-30% / -60%` — l'active est celle au tiers supérieur du viewport), highlight `bg-dusk-100`
- Horizontal scroll auto sur petits viewports

### `billet-form.tsx`

- Rend la nav juste au-dessus du `<form>`
- Ajoute `id="billet-section-*"` + `scroll-mt-24` à chaque Card (évite que le titre passe sous la nav après anchor jump)
- Les 4 titres de card passent par le nouvel i18n `billets.sections.*` (fr/en) — remplace les strings hardcodés "Payeur" / "Planification" / "Passagers"

### i18n ajoutée

Sous `billets.sections` (fr/en) :
- `payeur` / `planification` / `passagers` / `bonCadeau`

## Closes

Closes #6.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Vercel preview : créer/éditer un billet sur mobile → scroll → la section active change dans la nav ; clic sur une pill → scroll lisse vers la section sans que le titre passe sous la nav

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32