### PR TITLE
security(#27): requireAuth default role → EQUIPIER (least privilege)

### DIFF
--- a/lib/auth/requireAuth.ts
+++ b/lib/auth/requireAuth.ts
@@ -13,7 +13,12 @@ export async function requireAuth<T>(fn: () => Promise<T>): Promise<T> {
 
   const user = session.user as Record<string, unknown>
   const exploitantId = user.exploitantId as string
-  const role = (user.role as string) ?? 'GERANT'
+  // Least-privilege fallback: `User.role` is `UserRole NOT NULL` in Prisma
+  // so the DB can't return null, but a session claim without a role (race
+  // condition, legacy cookie) still falls through here. Defaulting to
+  // EQUIPIER keeps the user locked out of elevated pages until the claim
+  // is resolved, matching the sidebar default from issue #35.
+  const role = (user.role as string) ?? 'EQUIPIER'
 
   // ADMIN_CALPAX can operate without a tenant (super-admin actions use adminDb).
   // Today the DB schema enforces exploitantId on all users, but this guard


### PR DESCRIPTION
## Summary

Traite **#27** — flip le fallback de rôle dans `lib/auth/requireAuth.ts` de `GERANT` vers `EQUIPIER` (least privilege).

## Safety check

Prisma schema ligne 136 :
```prisma
role UserRole @default(GERANT)
```

→ `NOT NULL DEFAULT 'GERANT'`. Postgres ne peut pas renvoyer null sur cette colonne. Le fallback ne se déclenche que quand **le claim session** manque (cookie legacy pré-role, race condition). Aucun user live n'est affecté.

## Pourquoi EQUIPIER

- Defense en profondeur : un claim session cassé ne doit pas promouvoir l'utilisateur à GERANT
- Les `requireRole(...)` côté serveur font la vraie barrière — EQUIPIER déclenche 403 sur les pages sensibles
- Cohérent avec la sidebar qui flip son default vers EQUIPIER dans PR #62

## Closes

Closes #27.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 16/16 fichiers, 135/135 tests
- [ ] Manuel : forcer un cookie session sans claim role → vérifier que l'app traite l'user comme EQUIPIER (sidebar minimale, 403 sur /settings)

https://claude.ai/code/session_01AKMABsaLckCYtLLVv6MT32