### PR TITLE
review+tests(#69): GDPR audit + PVE role gate + automated coverage

### DIFF
--- a/app/[locale]/admin/invitations/invitation-form.tsx
+++ b/app/[locale]/admin/invitations/invitation-form.tsx
@@ -78,10 +78,6 @@ export function InvitationForm({
     }
   }
 
-  function formatDate(date: Date) {
-    return new Date(date).toLocaleString('fr-FR')
-  }
-
   return (
     <div className="space-y-6">
       <Card>

--- a/app/api/vols/[id]/fiche-vol/route.ts
+++ b/app/api/vols/[id]/fiche-vol/route.ts
@@ -1,11 +1,25 @@
 import { NextResponse } from 'next/server'
 import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireRole } from '@/lib/auth/requireRole'
+import { getContext } from '@/lib/context'
+import { db } from '@/lib/db'
 import { generateFicheVolBuffer } from '@/lib/pdf/generate'
 import { buildFicheVolData } from '@/lib/pdf/build-data'
+import { buildVolWhereForRole } from '@/lib/vol/role-filter'
 
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   return requireAuth(async () => {
     const { id } = await params
+    // Fiche-vol embeds decrypted passenger weights (RGPD). EQUIPIER has no
+    // access; PILOTE is restricted to vols they flew via buildVolWhereForRole.
+    requireRole('ADMIN_CALPAX', 'GERANT', 'PILOTE')
+    const ctx = getContext()
+
+    const where = buildVolWhereForRole({ id }, ctx.role, ctx.userId)
+    const owned = await db.vol.findFirst({ where, select: { id: true } })
+    if (!owned) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
 
     const { data, vol } = await buildFicheVolData(id)
     const buffer = await generateFicheVolBuffer(data)
@@ -18,6 +32,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
       headers: {
         'Content-Type': 'application/pdf',
         'Content-Disposition': `attachment; filename="${filename}"`,
+        // Fiche-vol bodies contain passenger PII. Never cache on CDN or browser.
+        'Cache-Control': 'private, no-store',
       },
     })
   })

--- a/app/api/vols/[id]/pve/route.ts
+++ b/app/api/vols/[id]/pve/route.ts
@@ -1,13 +1,24 @@
 import { NextResponse } from 'next/server'
 import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireRole } from '@/lib/auth/requireRole'
+import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
 import { getSignedPveUrl } from '@/lib/storage/pve'
+import { buildVolWhereForRole } from '@/lib/vol/role-filter'
 
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   return requireAuth(async () => {
     const { id } = await params
-    const vol = await db.vol.findUniqueOrThrow({ where: { id } })
+    // EQUIPIER has no access to PVE documents (sensitive passenger data).
+    // PILOTE can only fetch PVEs for vols they flew.
+    requireRole('ADMIN_CALPAX', 'GERANT', 'PILOTE')
+    const ctx = getContext()
 
+    const where = buildVolWhereForRole({ id }, ctx.role, ctx.userId)
+    const vol = await db.vol.findFirst({ where, select: { pvePdfUrl: true } })
+    if (!vol) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
     if (!vol.pvePdfUrl) {
       return NextResponse.json({ error: 'PVE not archived yet' }, { status: 404 })
     }

--- a/components/passager-table-editor.tsx
+++ b/components/passager-table-editor.tsx
@@ -122,7 +122,14 @@ export function PassagerTableEditor({ passagers, onChange }: Props) {
                 />
               </TableCell>
               <TableCell>
-                <Button type="button" variant="ghost" size="sm" onClick={() => removeRow(i)}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeRow(i)}
+                  aria-label={t('removeRow')}
+                  title={t('removeRow')}
+                >
                   X
                 </Button>
               </TableCell>
@@ -131,7 +138,7 @@ export function PassagerTableEditor({ passagers, onChange }: Props) {
         </TableBody>
       </Table>
       <Button type="button" variant="outline" size="sm" onClick={addRow}>
-        + Passager
+        + {t('addRow')}
       </Button>
     </div>
   )

--- a/lib/actions/rgpd.ts
+++ b/lib/actions/rgpd.ts
@@ -1,7 +1,10 @@
 'use server'
 
+import { AuditAction } from '@prisma/client'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { requireRole } from '@/lib/auth/requireRole'
+import { writeAudit } from '@/lib/audit/write'
+import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
 import { decrypt, safeDecryptString } from '@/lib/crypto'
 
@@ -14,6 +17,18 @@ export type PassagerSearchResult = {
   billetReference: string
   billetId: string
 }
+
+const selectFields = {
+  id: true,
+  prenom: true,
+  nom: true,
+  email: true,
+  telephone: true,
+  emailEncrypted: true,
+  telephoneEncrypted: true,
+  billetId: true,
+  billet: { select: { reference: true } },
+} as const
 
 /**
  * Reads the encrypted column first (authoritative post-#4 backfill) and
@@ -89,12 +104,13 @@ export async function searchPassagers(query: string): Promise<PassagerSearchResu
       billetReference: p.billet.reference,
       billetId: p.billetId,
     }))
-  }) as Promise<PassagerSearchResult[]>
+  })
 }
 
 export async function exportPassagerData(passagerId: string): Promise<string> {
   return requireAuth(async () => {
     requireRole('ADMIN_CALPAX', 'GERANT')
+    const ctx = getContext()
     const passager = await db.passager.findUniqueOrThrow({
       where: { id: passagerId },
       include: { billet: { include: { paiements: true } } },
@@ -133,13 +149,26 @@ export async function exportPassagerData(passagerId: string): Promise<string> {
       exportedAt: new Date().toISOString(),
     }
 
+    // GDPR Art. 30: record every export of personal data. No PII in the log;
+    // just the fact that the export happened, who triggered it and which
+    // record was touched.
+    await writeAudit({
+      exploitantId: ctx.exploitantId,
+      userId: ctx.userId,
+      impersonatedBy: ctx.impersonatedBy ?? null,
+      entityType: 'Passager',
+      entityId: passager.id,
+      action: AuditAction.EXPORT_PII,
+    })
+
     return JSON.stringify(data, null, 2)
-  }) as Promise<string>
+  })
 }
 
 export async function anonymisePassager(passagerId: string): Promise<{ error?: string }> {
   return requireAuth(async () => {
     requireRole('ADMIN_CALPAX', 'GERANT')
+    const ctx = getContext()
     await db.passager.update({
       where: { id: passagerId },
       data: {
@@ -154,18 +183,19 @@ export async function anonymisePassager(passagerId: string): Promise<{ error?: s
         pmr: false,
       },
     })
+
+    // GDPR Art. 17: the underlying UPDATE is already captured by the audit
+    // extension, but we emit an explicit ANONYMIZE_PII row so right-to-erasure
+    // events stay trivially queryable regardless of which fields changed.
+    await writeAudit({
+      exploitantId: ctx.exploitantId,
+      userId: ctx.userId,
+      impersonatedBy: ctx.impersonatedBy ?? null,
+      entityType: 'Passager',
+      entityId: passagerId,
+      action: AuditAction.ANONYMIZE_PII,
+    })
+
     return {}
   })
 }
-
-const selectFields = {
-  id: true,
-  prenom: true,
-  nom: true,
-  email: true,
-  telephone: true,
-  emailEncrypted: true,
-  telephoneEncrypted: true,
-  billetId: true,
-  billet: { select: { reference: true } },
-} as const

--- a/lib/pdf/fiche-vol.tsx
+++ b/lib/pdf/fiche-vol.tsx
@@ -372,7 +372,7 @@ function KV({ label, value }: { label: string; value: string }) {
 // ---------------------------------------------------------------------------
 
 function Page1({ data }: { data: FicheVolData }) {
-  const { exploitant, vol, ballon, pilote, passagers, temperatureCelsius, isPve } = data
+  const { exploitant, vol, ballon, pilote, passagers, temperatureCelsius } = data
 
   const devis = calculerDevisMasse({
     ballon: {

--- a/messages/en.json
+++ b/messages/en.json
@@ -586,7 +586,9 @@
       "age": "Age",
       "poids": "Weight (kg)",
       "pmr": "PRM"
-    }
+    },
+    "addRow": "Add passenger",
+    "removeRow": "Remove passenger"
   },
   "paiements": {
     "title": "Payments",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -586,7 +586,9 @@
       "age": "Âge",
       "poids": "Poids (kg)",
       "pmr": "PMR"
-    }
+    },
+    "addRow": "Ajouter un passager",
+    "removeRow": "Supprimer le passager"
   },
   "paiements": {
     "title": "Paiements",

--- a/prisma/migrations/20260423120000_audit_action_rgpd_events/migration.sql
+++ b/prisma/migrations/20260423120000_audit_action_rgpd_events/migration.sql
@@ -1,0 +1,6 @@
+-- GDPR: persistent audit trail for PII exports and passager anonymisation.
+-- Art. 30 (record of processing) + Art. 17 (right to erasure) demand a trace
+-- every time sensitive data leaves the system or is irreversibly scrubbed.
+
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'EXPORT_PII';
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'ANONYMIZE_PII';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,6 +211,8 @@ enum AuditAction {
   PASSWORD_RESET
   PASSWORD_CHANGED
   ACCOUNT_LOCKED
+  EXPORT_PII
+  ANONYMIZE_PII
 }
 
 enum TypePlannif {

--- a/tests/e2e/rbac.spec.ts
+++ b/tests/e2e/rbac.spec.ts
@@ -76,3 +76,29 @@ test('Cache-Control: no-store on protected app routes', async ({ page }) => {
   expect(response, 'expected a response for the dashboard').not.toBeNull()
   expect(response!.headers()['cache-control']).toContain('no-store')
 })
+
+/**
+ * API routes that serve PDFs embedding decrypted passenger PII
+ * (poids, email, telephone). `requireRole` runs before the DB lookup,
+ * so a bogus vol id is enough to prove an EQUIPIER is rejected before
+ * any data would be exposed.
+ */
+const PII_PDF_API_ROUTES = ['/api/vols/fake-vol-id/pve', '/api/vols/fake-vol-id/fiche-vol']
+
+test.describe.serial('RBAC — API PII PDFs', () => {
+  test('EQUIPIER is refused on PVE and fiche-vol APIs', async ({ page, request }) => {
+    await signIn(page, 'equipier@cameronfrance.com')
+    // Piggy-back on the session cookie from the Playwright page context.
+    const cookies = await page.context().cookies()
+    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ')
+
+    for (const route of PII_PDF_API_ROUTES) {
+      const res = await request.get(route, { headers: { cookie: cookieHeader } })
+      expect(res.status(), `EQUIPIER should not reach ${route}`).not.toBe(200)
+      // The handler may surface ForbiddenError as 403 or (without a global
+      // error boundary) bubble to 500. Either way, no PDF body is returned.
+      const ct = res.headers()['content-type'] ?? ''
+      expect(ct, `${route} must not return a PDF to EQUIPIER`).not.toContain('application/pdf')
+    }
+  })
+})

--- a/tests/integration/rgpd-audit.spec.ts
+++ b/tests/integration/rgpd-audit.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * RGPD audit trail — verifies the explicit EXPORT_PII / ANONYMIZE_PII rows
+ * emitted by `lib/actions/rgpd.ts`.
+ *
+ * The `audit-extension` ignores reads, so without the explicit `writeAudit`
+ * call inside `exportPassagerData` an Art. 30 export would leave no trace.
+ * The anonymisation UPDATE is already auto-captured, but we still emit an
+ * explicit ANONYMIZE_PII row to make Art. 17 events queryable without
+ * scanning every field-level UPDATE.
+ *
+ * `requireAuth` is mocked: the AsyncLocalStorage context is already set up
+ * by `asUser` (see tests/integration/helpers.ts), so we skip the Better
+ * Auth session lookup and invoke the callback in place. `requireRole` is
+ * NOT mocked — the ForbiddenError branches are part of what we want to
+ * cover.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+}))
+
+import { basePrisma } from '@/lib/db/base'
+import { encrypt } from '@/lib/crypto'
+import { resetDb, seedTenant, asUser } from './helpers'
+import { exportPassagerData, anonymisePassager } from '@/lib/actions/rgpd'
+
+async function seedBilletPassager(exploitantId: string) {
+  const billet = await basePrisma.billet.create({
+    data: {
+      exploitantId,
+      reference: `REF-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      checksum: '0',
+      payeurPrenom: 'Test',
+      payeurNom: 'Payeur',
+      montantTtc: 15000,
+    },
+  })
+  const passager = await basePrisma.passager.create({
+    data: {
+      exploitantId,
+      billetId: billet.id,
+      prenom: 'Jean',
+      nom: 'Dupont',
+      email: 'jean.dupont@test.local',
+      emailEncrypted: encrypt('jean.dupont@test.local'),
+      poidsEncrypted: encrypt('78'),
+    },
+  })
+  return { billet, passager }
+}
+
+async function rgpdRowsFor(passagerId: string, action: 'EXPORT_PII' | 'ANONYMIZE_PII') {
+  return basePrisma.auditLog.findMany({
+    where: { entityType: 'Passager', entityId: passagerId, action },
+  })
+}
+
+describe('rgpd audit trail', () => {
+  beforeEach(async () => {
+    await resetDb()
+  })
+
+  it('exportPassagerData writes an EXPORT_PII row with actor metadata and no PII', async () => {
+    const T = await seedTenant('EXPORT')
+    const { passager } = await seedBilletPassager(T.exploitantId)
+
+    const json = await asUser(T, 'GERANT', async () => exportPassagerData(passager.id))
+    // Sanity: the export actually contains the decrypted email
+    expect(JSON.parse(json).passager.email).toBe('jean.dupont@test.local')
+
+    const rows = await rgpdRowsFor(passager.id, 'EXPORT_PII')
+    expect(rows).toHaveLength(1)
+    const row = rows[0]!
+    expect(row.userId).toBe(T.userId)
+    expect(row.exploitantId).toBe(T.exploitantId)
+    expect(row.impersonatedBy).toBeNull()
+    // No PII on the audit row itself — just the fact that the export happened.
+    expect(row.field).toBeNull()
+    expect(row.beforeValue).toBeNull()
+    expect(row.afterValue).toBeNull()
+  })
+
+  it('exportPassagerData under impersonation records impersonatedBy', async () => {
+    const tenant = await seedTenant('IMPERSO_TENANT')
+    const admin = await seedTenant('IMPERSO_ADMIN')
+    const { passager } = await seedBilletPassager(tenant.exploitantId)
+
+    await asUser(
+      { exploitantId: tenant.exploitantId, userId: admin.userId },
+      'ADMIN_CALPAX',
+      async () => exportPassagerData(passager.id),
+      { impersonatedBy: admin.userId },
+    )
+
+    const rows = await rgpdRowsFor(passager.id, 'EXPORT_PII')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.userId).toBe(admin.userId)
+    expect(rows[0]?.impersonatedBy).toBe(admin.userId)
+    expect(rows[0]?.exploitantId).toBe(tenant.exploitantId)
+  })
+
+  it('anonymisePassager writes an ANONYMIZE_PII row alongside the field-level UPDATE rows', async () => {
+    const T = await seedTenant('ANON')
+    const { passager } = await seedBilletPassager(T.exploitantId)
+
+    await asUser(T, 'GERANT', async () => anonymisePassager(passager.id))
+
+    const rgpdRows = await rgpdRowsFor(passager.id, 'ANONYMIZE_PII')
+    expect(rgpdRows).toHaveLength(1)
+    expect(rgpdRows[0]?.userId).toBe(T.userId)
+
+    // The UPDATE is also captured by the audit extension, so the event is
+    // observable two ways: explicit (ANONYMIZE_PII) + implicit (UPDATE rows
+    // per scrubbed field).
+    const updateRows = await basePrisma.auditLog.findMany({
+      where: { entityType: 'Passager', entityId: passager.id, action: 'UPDATE' },
+    })
+    expect(updateRows.length).toBeGreaterThan(0)
+
+    // Passager has been scrubbed at the data layer.
+    const after = await basePrisma.passager.findUniqueOrThrow({ where: { id: passager.id } })
+    expect(after.prenom).toBe('SUPPRIME')
+    expect(after.nom).toBe('SUPPRIME')
+    expect(after.email).toBeNull()
+    expect(after.emailEncrypted).toBeNull()
+    expect(after.poidsEncrypted).toBeNull()
+  })
+
+  it('EQUIPIER cannot exportPassagerData (ForbiddenError) and no audit is written', async () => {
+    const T = await seedTenant('EQ_EXPORT')
+    const { passager } = await seedBilletPassager(T.exploitantId)
+
+    await expect(
+      asUser(T, 'EQUIPIER', async () => exportPassagerData(passager.id)),
+    ).rejects.toThrow()
+
+    const rows = await rgpdRowsFor(passager.id, 'EXPORT_PII')
+    expect(rows).toHaveLength(0)
+  })
+
+  it('PILOTE cannot anonymisePassager (ForbiddenError) and no audit is written', async () => {
+    const T = await seedTenant('PIL_ANON')
+    const { passager } = await seedBilletPassager(T.exploitantId)
+
+    await expect(asUser(T, 'PILOTE', async () => anonymisePassager(passager.id))).rejects.toThrow()
+
+    const rows = await rgpdRowsFor(passager.id, 'ANONYMIZE_PII')
+    expect(rows).toHaveLength(0)
+    // Data was not scrubbed
+    const untouched = await basePrisma.passager.findUniqueOrThrow({ where: { id: passager.id } })
+    expect(untouched.prenom).toBe('Jean')
+  })
+})


### PR DESCRIPTION
Bundle de #69 + des tests qui manquaient.

Ma branche est un fast-forward de la branche de #69, donc retargeter vers `main` inclut automatiquement :
1. Les changements de #69 (role gate PVE/fiche-vol, audit EXPORT_PII/ANONYMIZE_PII, migration enum, cleanup)
2. Les tests ajoutés ici pour couvrir les nouveaux controles

Si cette PR est mergée, **#69 peut être fermée** sans merge (le contenu passera par celle-ci).

## Ce qui vient de #69 (cf. PR #69 pour le détail)

- `requireRole` + `buildVolWhereForRole` sur `/api/vols/[id]/{pve,fiche-vol}` — EQUIPIER bloqué, PILOTE restreint à ses vols
- `EXPORT_PII` / `ANONYMIZE_PII` audit rows (Art. 30 + Art. 17 RGPD)
- `Cache-Control: private, no-store` sur la fiche-vol
- Migration enum additive (safe, non-bloquante)
- Dead code cleanup + a11y + i18n sur `passager-table-editor`

## Ce qui est ajouté ici

### Integration — `tests/integration/rgpd-audit.spec.ts`

- `exportPassagerData` écrit une seule ligne `EXPORT_PII` avec `userId` / `exploitantId` / `impersonatedBy` et zéro PII (`field`, `beforeValue`, `afterValue` null)
- Impersonation ADMIN_CALPAX → `impersonatedBy` correctement propagé
- `anonymisePassager` écrit une ligne `ANONYMIZE_PII` en plus des UPDATE field-level auto-capturées, et scrubbe effectivement les données
- `EQUIPIER` / `PILOTE` → `ForbiddenError`, aucune ligne d'audit émise pour l'appel refusé

`requireAuth` est mocké (passthrough) puisque `asUser` pose déjà le contexte ALS. `requireRole` n'est pas mocké — les branches Forbidden font partie de ce qu'on veut couvrir.

### E2E — `tests/e2e/rbac.spec.ts`

- `EQUIPIER` sur `GET /api/vols/<id>/{pve,fiche-vol}` : statut ≠ 200 et `content-type` ≠ `application/pdf`. Un id de vol bidon suffit puisque `requireRole` s'exécute avant le lookup DB.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — aucun nouveau warning
- [x] `pnpm test` — 135/135 pass (les nouveaux tests sont integration + e2e, tournent en CI)
- [ ] CI : lint + typecheck + unit + integration + build + e2e verts

https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR