### PR TITLE
a11y(#75): fix WindArrow aria-label + add progressbar role to LoadBar

### DIFF
--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -322,7 +322,16 @@ export default async function HomePage({ params }: Props) {
             label={t('kpi.wind')}
             value={maxWindKmh > 0 ? `${maxWindKmh}` : t('kpi.windEmpty')}
             sub={maxWindKmh > 0 ? t('kpi.windUnit') : null}
-            icon={maxWindKmh > 0 ? <WindArrow speed={maxWindKmh} size={16} /> : null}
+            icon={
+              maxWindKmh > 0 ? (
+                <WindArrow
+                  speed={maxWindKmh}
+                  unit="km/h"
+                  label={t('windAriaLabelKpi', { speed: maxWindKmh })}
+                  size={16}
+                />
+              ) : null
+            }
             tone={maxWindKmh >= seuilVent ? 'warn' : 'default'}
           />
           <KpiTile

--- a/components/cockpit/load-bar.tsx
+++ b/components/cockpit/load-bar.tsx
@@ -13,6 +13,10 @@ const TONE_COLOR: Record<LoadBarTone, string> = {
 /**
  * Jauge de remplissage horizontale — passagers, masse, carburant.
  * `showText` affiche `value/max` en mono à droite.
+ *
+ * Le rail interne expose le rôle ARIA `progressbar` avec `aria-valuemin/max/now`
+ * pour que les lecteurs d'écran annoncent la jauge sans dépendre du texte adjacent.
+ * `aria-label` (FR par défaut) est surchargeable via `ariaLabel`.
  */
 export function LoadBar({
   value,
@@ -21,6 +25,7 @@ export function LoadBar({
   height = 6,
   showText = false,
   label,
+  ariaLabel,
   className,
 }: {
   value: number
@@ -29,13 +34,24 @@ export function LoadBar({
   height?: number
   showText?: boolean
   label?: string
+  /** Override du aria-label du rail. Défaut : label visible ou "jauge". */
+  ariaLabel?: string
   className?: string
 }) {
   const pct = max > 0 ? Math.min(1, Math.max(0, value / max)) : 0
+  const railLabel = ariaLabel ?? label ?? 'jauge'
   return (
     <div className={cn('flex items-center gap-2', className)}>
       {label && <span className="min-w-10 text-[11px] text-sky-500">{label}</span>}
-      <div className="relative flex-1 overflow-hidden rounded-full bg-sky-100" style={{ height }}>
+      <div
+        className="relative flex-1 overflow-hidden rounded-full bg-sky-100"
+        style={{ height }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-label={`${railLabel} : ${value} sur ${max}`}
+      >
         <div
           className="h-full transition-[width] duration-300"
           style={{ width: `${pct * 100}%`, background: TONE_COLOR[tone] }}

--- a/components/cockpit/wind-arrow.tsx
+++ b/components/cockpit/wind-arrow.tsx
@@ -1,26 +1,35 @@
 /**
- * Flèche de vent — direction en degrés (0 = Nord), vitesse en nœuds.
- * Une barbule supplémentaire apparaît au-dessus de 12 kt (intensité).
+ * Flèche de vent — direction en degrés (0 = Nord), vitesse dans l'unité
+ * demandée par l'appelant (par défaut kt). Une barbule supplémentaire
+ * apparaît au-dessus de 12 kt d'intensité relative (pour illustrer fort
+ * vent, peu importe l'unité affichée).
  */
 export function WindArrow({
   direction = 0,
   speed = 0,
   size = 22,
+  unit = 'kt',
+  label,
   className,
 }: {
   direction?: number
   speed?: number
   size?: number
+  unit?: string
+  /** Override complet du aria-label. Si omis, construit depuis speed/unit/direction. */
+  label?: string
   className?: string
 }) {
   const intensity = Math.min(1, speed / 25)
+  const ariaLabel = label ?? `${Math.round(speed)} ${unit}, ${Math.round(direction)}°`
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 24 24"
       className={className}
-      aria-label={`Vent ${Math.round(speed)}kt ${Math.round(direction)}°`}
+      role="img"
+      aria-label={ariaLabel}
     >
       <g transform={`rotate(${direction} 12 12)`}>
         <line x1="12" y1="20" x2="12" y2="5" stroke="currentColor" strokeWidth="1.4" />

--- a/components/flight-card.tsx
+++ b/components/flight-card.tsx
@@ -116,6 +116,7 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
             max={flight.passagerMax}
             tone={CAPACITY_TONE(flight.passagerCount, flight.passagerMax)}
             showText
+            ariaLabel={t('capacity')}
           />
         </div>
       </div>
@@ -151,6 +152,7 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
             max={flight.massBudget.maxPayload}
             tone={MASS_TONE[flight.massBudget.status]}
             height={6}
+            ariaLabel={t('massLabel')}
           />
           <div className="flex justify-between text-[11px]">
             <MonoValue value={flight.massBudget.totalWeight} unit="kg" size={11} />
@@ -172,6 +174,10 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
             weather={flight.weather}
             creneauLabel={tv(`creneau.${flight.creneau}`)}
             goNogoLabel={t(`goNogo.${flight.weather.goNogo}`)}
+            windLabel={t('windAriaLabel', {
+              speed: flight.weather.maxWindKmh,
+              altitude: flight.weather.maxWindAltitude,
+            })}
           />
         </Suspense>
       )}
@@ -206,10 +212,12 @@ function WeatherStrip({
   weather,
   creneauLabel,
   goNogoLabel,
+  windLabel,
 }: {
   weather: FlightCardWeather
   creneauLabel: string
   goNogoLabel: string
+  windLabel: string
 }) {
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md bg-sky-50 px-3 py-2 text-sm">
@@ -217,7 +225,14 @@ function WeatherStrip({
         {creneauLabel} · {weather.creneauRange}
       </MonoLabel>
       <div className="flex items-center gap-1.5 text-sky-700">
-        <WindArrow direction={0} speed={weather.maxWindKmh} size={16} className="text-sky-500" />
+        <WindArrow
+          direction={0}
+          speed={weather.maxWindKmh}
+          unit="km/h"
+          label={windLabel}
+          size={16}
+          className="text-sky-500"
+        />
         <MonoValue value={weather.maxWindKmh} unit="km/h" size={12} />
         <span className="text-[10px] text-sky-400">({weather.maxWindAltitude})</span>
       </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -742,6 +742,8 @@
       "flightsSub": "Today"
     },
     "meteoAlert": "Wind forecast above threshold",
+    "windAriaLabel": "Max wind {speed} km/h at {altitude}",
+    "windAriaLabelKpi": "Max wind {speed} km/h",
     "meteoAlertAction": "Cancel this flight?",
     "cancelMeteo": "Cancel (weather)",
     "cancelMeteoConfirm": "Cancel this flight due to weather? Passengers will be unassigned and contacts notified by email.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -730,6 +730,8 @@
       "MARGINAL": "Limite"
     },
     "meteoAlert": "Vent prévu au-dessus du seuil",
+    "windAriaLabel": "Vent maximum {speed} km/h à {altitude}",
+    "windAriaLabelKpi": "Vent maximum {speed} km/h",
     "meteoAlertAction": "Annuler ce vol ?",
     "cancelMeteo": "Annuler (météo)",
     "cancelMeteoConfirm": "Annuler ce vol pour raison météo ? Les passagers seront désaffectés et les contacts notifiés par email.",


### PR DESCRIPTION
Closes #75.

## Scope ajustée

En auditant `flight-card.tsx`, les « boutons icon-only » mentionnés dans l'issue n'existent plus — la ligne d'actions utilise des boutons avec texte (Détail / Organiser). Mais l'audit a révélé deux bugs a11y concrets sur la même famille de composants :

1. **`WindArrow` aria-label cassé** : hardcodé FR (« Vent ») et annonçait la vitesse en `kt` alors que le dashboard et flight-card passent des `km/h`. Info fausse aux lecteurs d'écran.
2. **`LoadBar` sans rôle ARIA** : les jauges capacité + devis de masse transmettaient `value/max` uniquement visuellement, un lecteur d'écran passait directement au suivant.

## Fixes

### `components/cockpit/wind-arrow.tsx`
- Ajout props `unit` (défaut `'kt'` pour préserver les callers sans unité explicite) et `label` override
- `role="img"` + aria-label construit depuis `speed + unit + direction` quand `label` absent — plus de français hardcodé

### `components/cockpit/load-bar.tsx`
- `role="progressbar"` + `aria-valuemin` / `aria-valuemax` / `aria-valuenow` sur le rail
- Prop optionnel `ariaLabel` (défaut : prop `label` visible ou `'jauge'`)

### `components/flight-card.tsx`
- `ariaLabel` transmis aux deux `LoadBar` (capacité + masse)
- `unit="km/h"` + label localisé passé à `WindArrow` via nouveau prop `windLabel` sur `WeatherStrip`

### `app/[locale]/(app)/page.tsx`
- Même traitement sur le KPI vent du dashboard

### i18n
- `dashboard.windAriaLabel` (vol spécifique, avec altitude)
- `dashboard.windAriaLabelKpi` (KPI, sans altitude)
- Les deux paramétrées sur `{speed}` pour éviter toute dérive d'unité à l'avenir

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — aucun nouveau warning
- [x] `pnpm test` — 135/135 pass
- [ ] Manuel : VoiceOver / NVDA sur `/fr` — la jauge capacité doit être annoncée « Passagers, X sur Y » et le KPI vent « Vent maximum N km/h »

https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR)_