### PR TITLE
security(#76): rate-limit + timing-safe Bearer check on /api/cron/*

### DIFF
--- a/app/api/cron/digest/route.ts
+++ b/app/api/cron/digest/route.ts
@@ -1,26 +1,20 @@
 import { basePrisma } from '@/lib/db/base'
 import { buildBallonAlerts, buildPiloteAlerts, sortAlerts } from '@/lib/regulatory/alerts'
 import { sendDigestEmail } from '@/lib/email/digest'
+import { verifyCronRequest } from '@/lib/auth/cron'
 import { logger } from '@/lib/logger'
+
+// 6 day cooldown: weekly schedule in vercel.json (Mon 07:00 UTC).
+const MIN_INTERVAL_MS = 6 * 24 * 60 * 60 * 1000
 
 /**
  * Weekly digest cron endpoint.
  * Called by Vercel Cron every Monday at 07:00 UTC.
- * Requires Authorization: Bearer <CRON_SECRET> header.
+ * Requires Authorization: Bearer <CRON_SECRET> header + per-endpoint cooldown.
  */
 export async function GET(request: Request): Promise<Response> {
-  const authHeader = request.headers.get('Authorization')
-  const cronSecret = process.env.CRON_SECRET
-
-  if (!cronSecret) {
-    logger.error('CRON_SECRET is not configured')
-    return Response.json({ error: 'Server misconfiguration' }, { status: 500 })
-  }
-
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    logger.warn('Unauthorized cron digest request')
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const guard = await verifyCronRequest(request, 'digest', { minIntervalMs: MIN_INTERVAL_MS })
+  if (!guard.ok) return guard.response
 
   const today = new Date()
 

--- a/app/api/cron/meteo-alert/route.ts
+++ b/app/api/cron/meteo-alert/route.ts
@@ -3,29 +3,26 @@ import { fetchWeatherFromAPI } from '@/lib/weather/open-meteo'
 import { parseOpenMeteoResponse, type OpenMeteoResponse } from '@/lib/weather/parse'
 import { extractCreneauHours } from '@/lib/weather/extract'
 import { summarizeWeather } from '@/lib/weather/classify'
+import { verifyCronRequest } from '@/lib/auth/cron'
 import { logger } from '@/lib/logger'
 
 const CACHE_TTL_MS = 30 * 60 * 1000 // 30 minutes
 
+// 15 min cooldown: supports any cadence ≥ every-15-min, caps abuse of a leaked
+// CRON_SECRET to ~96 invocations/day even though current Vercel schedule is
+// once-daily at 05:00 UTC (cf. vercel.json).
+const MIN_INTERVAL_MS = 15 * 60 * 1000
+
 /**
  * Weather alert cron endpoint.
- * Runs every 30 minutes between 03:00 and 18:00 UTC.
  * Flags or clears meteoAlert on vols scheduled for today based on wind threshold.
- * Requires Authorization: Bearer <CRON_SECRET> header.
+ * Requires Authorization: Bearer <CRON_SECRET> header + per-endpoint cooldown.
  */
 export async function GET(request: Request): Promise<Response> {
-  const authHeader = request.headers.get('Authorization')
-  const cronSecret = process.env.CRON_SECRET
-
-  if (!cronSecret) {
-    logger.error('CRON_SECRET is not configured')
-    return Response.json({ error: 'Server misconfiguration' }, { status: 500 })
-  }
-
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    logger.warn('Unauthorized cron meteo-alert request')
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const guard = await verifyCronRequest(request, 'meteo-alert', {
+    minIntervalMs: MIN_INTERVAL_MS,
+  })
+  if (!guard.ok) return guard.response
 
   const today = new Date()
   today.setHours(0, 0, 0, 0)

--- a/app/api/cron/rappels/route.ts
+++ b/app/api/cron/rappels/route.ts
@@ -1,25 +1,20 @@
 import { basePrisma } from '@/lib/db/base'
 import { sendRappelEmail } from '@/lib/email/rappels'
+import { verifyCronRequest } from '@/lib/auth/cron'
 import { logger } from '@/lib/logger'
+
+// 20 hour cooldown: daily schedule in vercel.json (07:00 UTC). Slightly under
+// 24h to give Vercel some scheduling tolerance.
+const MIN_INTERVAL_MS = 20 * 60 * 60 * 1000
 
 /**
  * Daily billet reminder cron endpoint.
  * Called by Vercel Cron every day at 07:00 UTC.
- * Requires Authorization: Bearer <CRON_SECRET> header.
+ * Requires Authorization: Bearer <CRON_SECRET> header + per-endpoint cooldown.
  */
 export async function GET(request: Request): Promise<Response> {
-  const authHeader = request.headers.get('Authorization')
-  const cronSecret = process.env.CRON_SECRET
-
-  if (!cronSecret) {
-    logger.error('CRON_SECRET is not configured')
-    return Response.json({ error: 'Server misconfiguration' }, { status: 500 })
-  }
-
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    logger.warn('Unauthorized cron rappels request')
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const guard = await verifyCronRequest(request, 'rappels', { minIntervalMs: MIN_INTERVAL_MS })
+  if (!guard.ok) return guard.response
 
   const today = new Date()
   today.setHours(0, 0, 0, 0)

--- a/app/api/cron/rgpd-retention/route.ts
+++ b/app/api/cron/rgpd-retention/route.ts
@@ -1,7 +1,12 @@
 import { AuditAction } from '@prisma/client'
 import { basePrisma } from '@/lib/db/base'
 import { writeAudit } from '@/lib/audit/write'
+import { verifyCronRequest } from '@/lib/auth/cron'
 import { logger } from '@/lib/logger'
+
+// 6 day cooldown: weekly schedule in vercel.json (Mon 06:00 UTC). A leaked
+// secret can only trigger a full scrub pass at that cadence, not in a loop.
+const MIN_INTERVAL_MS = 6 * 24 * 60 * 60 * 1000
 
 /**
  * RGPD 5-year retention cron. Anonymises PII on Billets + Passagers whose
@@ -23,18 +28,10 @@ import { logger } from '@/lib/logger'
  * Requires `Authorization: Bearer $CRON_SECRET`.
  */
 export async function GET(request: Request): Promise<Response> {
-  const authHeader = request.headers.get('Authorization')
-  const cronSecret = process.env.CRON_SECRET
-
-  if (!cronSecret) {
-    logger.error('CRON_SECRET is not configured')
-    return Response.json({ error: 'Server misconfiguration' }, { status: 500 })
-  }
-
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    logger.warn('Unauthorized rgpd-retention cron request')
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const guard = await verifyCronRequest(request, 'rgpd-retention', {
+    minIntervalMs: MIN_INTERVAL_MS,
+  })
+  if (!guard.ok) return guard.response
 
   const now = new Date()
   const cutoff = new Date(now)

--- a/lib/auth/cron.ts
+++ b/lib/auth/cron.ts
@@ -1,0 +1,88 @@
+import { timingSafeEqual } from 'node:crypto'
+import { basePrisma } from '@/lib/db/base'
+import { logger } from '@/lib/logger'
+
+/**
+ * Cron endpoint guard used by every `app/api/cron/*` route handler.
+ *
+ * Two layers of protection stacked on top of the Bearer-secret check:
+ *
+ * 1. **Timing-safe secret comparison** — replaces the naive `!==` check so
+ *    a leaked-secret probe can't observe a timing side channel.
+ * 2. **Per-endpoint cooldown** — one row per endpoint in `cron_invocation`,
+ *    upserted on accept. If a caller hits the endpoint again before
+ *    `minIntervalMs` has elapsed, we return 429. This caps the blast radius
+ *    of a leaked `CRON_SECRET` without breaking Vercel's normal cadence.
+ *
+ * Usage inside a route handler:
+ *
+ * ```ts
+ * const guard = await verifyCronRequest(request, 'meteo-alert', { minIntervalMs: 25 * 60 * 1000 })
+ * if (!guard.ok) return guard.response
+ * ```
+ */
+export type CronGuardResult = { ok: true } | { ok: false; response: Response }
+
+export async function verifyCronRequest(
+  request: Request,
+  endpoint: string,
+  opts: { minIntervalMs: number },
+): Promise<CronGuardResult> {
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    logger.error({ endpoint }, 'CRON_SECRET is not configured')
+    return {
+      ok: false,
+      response: Response.json({ error: 'Server misconfiguration' }, { status: 500 }),
+    }
+  }
+
+  // 1. Bearer secret — timing-safe compare.
+  const authHeader = request.headers.get('Authorization') ?? ''
+  const expected = `Bearer ${cronSecret}`
+  if (!equalsConstantTime(authHeader, expected)) {
+    logger.warn({ endpoint }, 'Unauthorized cron request: bad or missing Bearer token')
+    return { ok: false, response: Response.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  // 2. Cooldown gate. Read the last invocation for this endpoint and reject
+  //    anything too frequent. The write happens after the gate passes so a
+  //    rejected probe doesn't reset the cooldown window in the attacker's
+  //    favour.
+  const now = new Date()
+  const last = await basePrisma.cronInvocation.findUnique({ where: { endpoint } })
+  if (last && now.getTime() - last.lastInvokedAt.getTime() < opts.minIntervalMs) {
+    const retryAfterMs = opts.minIntervalMs - (now.getTime() - last.lastInvokedAt.getTime())
+    logger.warn(
+      { endpoint, sinceMs: now.getTime() - last.lastInvokedAt.getTime() },
+      'Cron request rate-limited',
+    )
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'Too Many Requests' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(Math.ceil(retryAfterMs / 1000)) },
+        },
+      ),
+    }
+  }
+
+  await basePrisma.cronInvocation.upsert({
+    where: { endpoint },
+    update: { lastInvokedAt: now },
+    create: { endpoint, lastInvokedAt: now },
+  })
+
+  return { ok: true }
+}
+
+function equalsConstantTime(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a)
+  const bBuf = Buffer.from(b)
+  // `timingSafeEqual` throws when the buffers differ in length, so we short-
+  // circuit. Still leaks the *length* of the secret, but not its content.
+  if (aBuf.length !== bBuf.length) return false
+  return timingSafeEqual(aBuf, bBuf)
+}

--- a/prisma/migrations/20260424202857_cron_invocation/migration.sql
+++ b/prisma/migrations/20260424202857_cron_invocation/migration.sql
@@ -1,0 +1,9 @@
+-- #76: per-endpoint cooldown backing the cron rate limiter in lib/auth/cron.ts.
+-- One row per cron endpoint; upserted on every successful invocation.
+
+CREATE TABLE "cron_invocation" (
+  "endpoint"       TEXT NOT NULL,
+  "lastInvokedAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "cron_invocation_pkey" PRIMARY KEY ("endpoint")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -553,3 +553,13 @@ model WeatherCache {
   @@index([exploitantId])
   @@map("weather_cache")
 }
+
+// Tracks successful cron endpoint invocations so the route handlers can
+// enforce a per-endpoint cooldown on top of the Bearer-secret check.
+// Not tenant-scoped: crons run at the platform level, one row per endpoint.
+model CronInvocation {
+  endpoint     String   @id
+  lastInvokedAt DateTime @default(now())
+
+  @@map("cron_invocation")
+}

--- a/tests/integration/cron-auth.spec.ts
+++ b/tests/integration/cron-auth.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Cron endpoint guard — verifies `verifyCronRequest` from `lib/auth/cron.ts`.
+ *
+ * Covers:
+ *  - Bearer secret accepted / rejected (constant-time compare)
+ *  - Missing CRON_SECRET env → 500
+ *  - Cooldown enforcement (429 within the window, 200 after)
+ *  - The `cron_invocation` row is only upserted on accept (failed calls don't
+ *    slide the cooldown window in an attacker's favour)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { basePrisma } from '@/lib/db/base'
+import { verifyCronRequest } from '@/lib/auth/cron'
+
+const SECRET = 'test-secret-cron-xyz'
+
+function makeRequest(authHeader?: string): Request {
+  const headers: Record<string, string> = {}
+  if (authHeader !== undefined) headers['Authorization'] = authHeader
+  return new Request('http://localhost/api/cron/test', { headers })
+}
+
+describe('verifyCronRequest', () => {
+  const originalSecret = process.env.CRON_SECRET
+
+  beforeEach(async () => {
+    process.env.CRON_SECRET = SECRET
+    await basePrisma.cronInvocation.deleteMany({})
+  })
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.CRON_SECRET
+    else process.env.CRON_SECRET = originalSecret
+  })
+
+  it('accepts a valid Bearer token on first call and records the invocation', async () => {
+    const result = await verifyCronRequest(makeRequest(`Bearer ${SECRET}`), 'test-endpoint', {
+      minIntervalMs: 1000,
+    })
+    expect(result.ok).toBe(true)
+
+    const row = await basePrisma.cronInvocation.findUnique({ where: { endpoint: 'test-endpoint' } })
+    expect(row).not.toBeNull()
+  })
+
+  it('rejects a missing Authorization header with 401 and does NOT record', async () => {
+    const result = await verifyCronRequest(makeRequest(), 'test-endpoint-missing', {
+      minIntervalMs: 1000,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.response.status).toBe(401)
+    }
+
+    // No row written — rejected calls must not advance the cooldown clock.
+    const row = await basePrisma.cronInvocation.findUnique({
+      where: { endpoint: 'test-endpoint-missing' },
+    })
+    expect(row).toBeNull()
+  })
+
+  it('rejects a wrong Bearer token with 401', async () => {
+    const result = await verifyCronRequest(
+      makeRequest('Bearer wrong-secret'),
+      'test-endpoint-wrong',
+      { minIntervalMs: 1000 },
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.response.status).toBe(401)
+  })
+
+  it('rejects a malformed Authorization header with 401 (same length, different bytes)', async () => {
+    // Same byte length as `Bearer ${SECRET}` to exercise the timing-safe path.
+    const malformed = `Bearer ${'x'.repeat(SECRET.length)}`
+    expect(malformed.length).toBe(`Bearer ${SECRET}`.length)
+    const result = await verifyCronRequest(makeRequest(malformed), 'test-endpoint-malformed', {
+      minIntervalMs: 1000,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.response.status).toBe(401)
+  })
+
+  it('returns 500 when CRON_SECRET is not configured', async () => {
+    delete process.env.CRON_SECRET
+    const result = await verifyCronRequest(makeRequest('Bearer anything'), 'test-no-secret', {
+      minIntervalMs: 1000,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.response.status).toBe(500)
+  })
+
+  it('rejects a second call within the cooldown window with 429 and Retry-After', async () => {
+    const cooldownMs = 60_000
+    // First call — accepted, records lastInvokedAt = now.
+    const ok1 = await verifyCronRequest(makeRequest(`Bearer ${SECRET}`), 'test-cooldown', {
+      minIntervalMs: cooldownMs,
+    })
+    expect(ok1.ok).toBe(true)
+
+    // Second call — immediately after, must be rate-limited.
+    const ok2 = await verifyCronRequest(makeRequest(`Bearer ${SECRET}`), 'test-cooldown', {
+      minIntervalMs: cooldownMs,
+    })
+    expect(ok2.ok).toBe(false)
+    if (!ok2.ok) {
+      expect(ok2.response.status).toBe(429)
+      const retryAfter = ok2.response.headers.get('Retry-After')
+      expect(retryAfter).not.toBeNull()
+      expect(Number(retryAfter)).toBeGreaterThan(0)
+    }
+  })
+
+  it('accepts a second call after the cooldown has elapsed', async () => {
+    // Simulate: the previous invocation happened well before the cooldown
+    // window — we seed the row with a lastInvokedAt far in the past.
+    await basePrisma.cronInvocation.create({
+      data: {
+        endpoint: 'test-past-cooldown',
+        lastInvokedAt: new Date(Date.now() - 10 * 60 * 1000),
+      },
+    })
+
+    const result = await verifyCronRequest(makeRequest(`Bearer ${SECRET}`), 'test-past-cooldown', {
+      minIntervalMs: 60_000, // 1 min — already elapsed
+    })
+    expect(result.ok).toBe(true)
+
+    // The row's lastInvokedAt was refreshed.
+    const row = await basePrisma.cronInvocation.findUniqueOrThrow({
+      where: { endpoint: 'test-past-cooldown' },
+    })
+    expect(Date.now() - row.lastInvokedAt.getTime()).toBeLessThan(5_000)
+  })
+
+  it('rate-limited calls do NOT refresh the lastInvokedAt timestamp', async () => {
+    const endpoint = 'test-no-refresh-on-reject'
+    await basePrisma.cronInvocation.create({
+      data: { endpoint, lastInvokedAt: new Date(Date.now() - 100) },
+    })
+    const before = await basePrisma.cronInvocation.findUniqueOrThrow({ where: { endpoint } })
+
+    // Hammer with the valid secret but within the cooldown window.
+    for (let i = 0; i < 3; i++) {
+      const r = await verifyCronRequest(makeRequest(`Bearer ${SECRET}`), endpoint, {
+        minIntervalMs: 60_000,
+      })
+      expect(r.ok).toBe(false)
+    }
+
+    const after = await basePrisma.cronInvocation.findUniqueOrThrow({ where: { endpoint } })
+    expect(after.lastInvokedAt.getTime()).toBe(before.lastInvokedAt.getTime())
+  })
+})


### PR DESCRIPTION
Closes #76. Deux couches de défense en profondeur sur la route cron, pour qu'une fuite du `CRON_SECRET` n'ait plus un impact illimité.

## Ce que ça change

### Nouveau helper : `lib/auth/cron.ts::verifyCronRequest`
Guard drop-in utilisée en tête de chaque `/api/cron/*`. Remplace le `authHeader !== Bearer ${cronSecret}` dupliqué sur les 4 routes.

1. **Comparaison Bearer timing-safe** — `crypto.timingSafeEqual` à la place de `!==`. Ferme un side-channel théorique sur un probe de secret. Court-circuit si les longueurs diffèrent (fuit la longueur, pas le contenu).

2. **Cooldown par endpoint** — un `CRON_SECRET` fuité pouvait être utilisé à fréquence arbitraire. Maintenant chaque endpoint a un `minIntervalMs`, les requêtes trop rapprochées retournent 429 + `Retry-After`. État dans la nouvelle table `cron_invocation` (une ligne par endpoint, upsertée **uniquement sur accept** — les appels rejetés n'avancent pas la fenêtre).

### Prisma
- Nouveau modèle `CronInvocation` + migration `20260424202857_cron_invocation` (table simple, pas de tenant scoping — les crons sont platform-level).

### Routes mises à jour (les 4)

| Route | Cooldown | Rationale |
|---|---|---|
| `digest` | 6 jours | Schedule hebdo (Mon 07:00 UTC) |
| `meteo-alert` | 15 min | Supporte la cadence "toutes les 30 min" de CLAUDE.md ; vercel.json = 05:00 UTC aujourd'hui |
| `rappels` | 20 h | Schedule quotidien 07:00 UTC, marge de sécurité |
| `rgpd-retention` | 6 jours | Schedule hebdo (Mon 06:00 UTC) |

Net : **-50 lignes** de boilerplate dupliqué sur les 4 routes.

## Tests

`tests/integration/cron-auth.spec.ts` :
- accept sur Bearer valide (ligne créée)
- reject sur Bearer manquant / faux / même longueur mais bytes différents (exerce le chemin timing-safe)
- 500 si `CRON_SECRET` non configuré
- 429 + `Retry-After` dans la fenêtre de cooldown
- accept après cooldown écoulé
- les appels rejetés ne rafraîchissent PAS `lastInvokedAt` (attaquant ne peut pas maintenir la fenêtre ouverte en hammerant)

## Verified

- `pnpm typecheck` — clean
- `pnpm lint` — aucun nouveau warning
- `pnpm test` — 135/135 pass (les nouveaux tests sont integration, tournent en CI)

https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR)_