### PR TITLE
feat(#59): wire ADMIN_CALPAX → exploitant impersonation flow

### DIFF
--- a/app/[locale]/(app)/layout.tsx
+++ b/app/[locale]/(app)/layout.tsx
@@ -1,5 +1,5 @@
 import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { SidebarProvider, SidebarInset, SidebarTrigger } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
@@ -9,6 +9,10 @@ import { CalpaxWordmark } from '@/components/brand/calpax-wordmark'
 import { runWithContext } from '@/lib/context'
 import { db } from '@/lib/db'
 import { buildBallonAlerts, buildPiloteAlerts, sortAlerts } from '@/lib/regulatory/alerts'
+import {
+  IMPERSONATION_COOKIE_NAME,
+  verifyImpersonationCookie,
+} from '@/lib/auth/impersonation-cookie'
 import type { Alert } from '@/lib/regulatory/alerts'
 import type { UserRole } from '@/lib/context'
 
@@ -36,19 +40,42 @@ export default async function AppLayout({ children, params }: Props) {
   }
 
   const user = session.user as Record<string, unknown>
-  const exploitantId = user.exploitantId as string
+  const sessionExploitantId = user.exploitantId as string
   const role = (user.role as string as UserRole) ?? 'GERANT'
   const showAlerts = canSeeRegulatoryAlerts(role)
 
-  // Better Auth's admin plugin sets `session.session.impersonatedBy` when an
-  // ADMIN_CALPAX is impersonating another user. We show the banner on every
-  // page so the admin can't lose track of their operating context.
+  // Two flavours of impersonation can be active simultaneously, but only one
+  // wins for the layout banner — exploitant-level (cookie) takes precedence
+  // since it changes the data we render on this very page.
+  //
+  // 1. Better Auth admin plugin → user-level: `session.session.impersonatedBy`
+  // 2. ADMIN_CALPAX → exploitant cookie (#59): signed cookie carrying target
+  //    exploitantId; honoured by `requireAuth` for downstream queries.
   const sessionMeta = (session as unknown as { session?: { impersonatedBy?: string | null } })
     .session
-  const impersonatedBy = sessionMeta?.impersonatedBy ?? null
-  const impersonationTargetName = impersonatedBy
-    ? ((user.name as string) ?? (user.email as string) ?? '?')
-    : null
+  const userImpersonatedBy = sessionMeta?.impersonatedBy ?? null
+
+  let impersonationKind: 'user' | 'exploitant' | null = null
+  let impersonationTargetName: string | null = null
+  let exploitantId = sessionExploitantId
+
+  if (role === 'ADMIN_CALPAX') {
+    const cookieStore = await cookies()
+    const claim = verifyImpersonationCookie(cookieStore.get(IMPERSONATION_COOKIE_NAME)?.value)
+    if (claim && claim.adminUserId === session.user.id) {
+      impersonationKind = 'exploitant'
+      // Name is snapshotted in the cookie at start time; may go stale within
+      // the 4h TTL if the exploitant is renamed. Acceptable trade-off vs. a
+      // cross-tenant DB hit on every page render.
+      impersonationTargetName = claim.targetName
+      exploitantId = claim.targetExploitantId
+    }
+  }
+
+  if (!impersonationKind && userImpersonatedBy) {
+    impersonationKind = 'user'
+    impersonationTargetName = (user.name as string) ?? (user.email as string) ?? '?'
+  }
 
   const { criticalAlerts, exploitantName, pendingTicketsCount } = await runWithContext(
     {
@@ -79,7 +106,9 @@ export default async function AppLayout({ children, params }: Props) {
         pendingTicketsCount={pendingTicketsCount}
       />
       <SidebarInset>
-        {impersonationTargetName && <ImpersonationBanner targetName={impersonationTargetName} />}
+        {impersonationKind && impersonationTargetName && (
+          <ImpersonationBanner targetName={impersonationTargetName} kind={impersonationKind} />
+        )}
         <header className="sticky top-0 z-10 flex h-12 items-center gap-2 border-b border-sky-100 bg-card px-4 md:hidden">
           <SidebarTrigger />
           <CalpaxWordmark size={14} />

--- a/app/[locale]/admin/page.tsx
+++ b/app/[locale]/admin/page.tsx
@@ -10,8 +10,8 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
-import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { startImpersonation } from '@/lib/admin/impersonation-actions'
 
 type Props = {
   params: Promise<{ locale: string }>
@@ -105,9 +105,16 @@ export default async function AdminDashboardPage({ params }: Props) {
                     <TableCell className="text-center">{exp._count.users}</TableCell>
                     <TableCell className="text-center">{exp._count.vols}</TableCell>
                     <TableCell>
-                      <Button variant="outline" size="sm" asChild>
-                        <Link href={`/${locale}?impersonate=${exp.id}`}>{t('impersonate')}</Link>
-                      </Button>
+                      <form
+                        action={async () => {
+                          'use server'
+                          await startImpersonation(exp.id, locale)
+                        }}
+                      >
+                        <Button type="submit" variant="outline" size="sm">
+                          {t('impersonate')}
+                        </Button>
+                      </form>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/components/impersonation-banner.tsx
+++ b/components/impersonation-banner.tsx
@@ -1,16 +1,22 @@
 'use client'
 
-import Link from 'next/link'
 import { useLocale, useTranslations } from 'next-intl'
 import { Eye } from 'lucide-react'
+import { stopImpersonation } from '@/lib/admin/impersonation-actions'
 
 type Props = {
   /**
    * Name displayed after "Connecté en tant que" — typically the impersonated
    * user's name when Better Auth's admin plugin is active, or an exploitant
-   * name for tenant-level impersonation.
+   * name for tenant-level impersonation (#59).
    */
   targetName: string
+  /**
+   * Distinguishes user-level impersonation (Better Auth admin plugin) from
+   * exploitant-level impersonation (#59 cookie). Drives whether "Revenir"
+   * runs the cookie-clearing server action or just links back to /admin.
+   */
+  kind: 'user' | 'exploitant'
 }
 
 /**
@@ -22,9 +28,13 @@ type Props = {
  * ~ 7.5:1 luminance ratio — WCAG AAA. Sticky top-0 z-40 so it stays
  * visible above the mobile header and content scroll.
  */
-export function ImpersonationBanner({ targetName }: Props) {
+export function ImpersonationBanner({ targetName, kind }: Props) {
   const locale = useLocale()
   const t = useTranslations('impersonation')
+
+  async function handleExit() {
+    await stopImpersonation(locale)
+  }
 
   return (
     <div
@@ -35,15 +45,27 @@ export function ImpersonationBanner({ targetName }: Props) {
       <div className="flex items-center gap-2">
         <Eye className="h-4 w-4 shrink-0" aria-hidden="true" />
         <span>
-          {t('connectedAs')} <strong>{targetName}</strong>
+          {kind === 'exploitant' ? t('connectedAsExploitant') : t('connectedAs')}{' '}
+          <strong>{targetName}</strong>
         </span>
       </div>
-      <Link
-        href={`/${locale}/admin`}
-        className="whitespace-nowrap rounded-md bg-amber-600 px-3 py-1.5 text-sm font-bold text-white transition-colors hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-      >
-        {t('exit')}
-      </Link>
+      {kind === 'exploitant' ? (
+        <form action={handleExit}>
+          <button
+            type="submit"
+            className="whitespace-nowrap rounded-md bg-amber-600 px-3 py-1.5 text-sm font-bold text-white transition-colors hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            {t('exit')}
+          </button>
+        </form>
+      ) : (
+        <a
+          href={`/${locale}/admin`}
+          className="whitespace-nowrap rounded-md bg-amber-600 px-3 py-1.5 text-sm font-bold text-white transition-colors hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        >
+          {t('exit')}
+        </a>
+      )}
     </div>
   )
 }

--- a/lib/admin/impersonation-actions.ts
+++ b/lib/admin/impersonation-actions.ts
@@ -1,0 +1,95 @@
+'use server'
+
+import { AuditAction } from '@prisma/client'
+import { cookies, headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { adminDb } from '@/lib/db'
+import { writeAudit } from '@/lib/audit/write'
+import {
+  IMPERSONATION_COOKIE_NAME,
+  IMPERSONATION_TTL_MS,
+  signImpersonationCookie,
+  verifyImpersonationCookie,
+} from '@/lib/auth/impersonation-cookie'
+import { ForbiddenError, UnauthorizedError } from '@/lib/errors'
+
+/**
+ * ADMIN_CALPAX action — sets the impersonation cookie targeting the given
+ * exploitant, emits an `IMPERSONATE_START` audit row, then redirects to
+ * the dashboard so the swap takes effect on the next request.
+ *
+ * Validates the admin's session AND role server-side; the cookie is signed
+ * with `BETTER_AUTH_SECRET` so a tampered or stolen value is rejected on
+ * read by `requireAuth`.
+ */
+export async function startImpersonation(
+  targetExploitantId: string,
+  locale: string,
+): Promise<void> {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session?.user) throw new UnauthorizedError()
+
+  const role = (session.user as Record<string, unknown>).role as string | undefined
+  if (role !== 'ADMIN_CALPAX') throw new ForbiddenError()
+
+  const adminUserId = session.user.id
+
+  // Cross-tenant lookup is the legit super-admin pattern. We snapshot the
+  // display name into the cookie so the layout banner doesn't have to hit
+  // the DB on every request.
+  const target = await adminDb.exploitant.findUnique({
+    where: { id: targetExploitantId },
+    select: { name: true, frDecNumber: true },
+  })
+  if (!target) throw new ForbiddenError('Unknown exploitant')
+
+  const targetName = `${target.name} (${target.frDecNumber})`
+  const cookieValue = signImpersonationCookie(adminUserId, targetExploitantId, targetName)
+  const store = await cookies()
+  store.set(IMPERSONATION_COOKIE_NAME, cookieValue, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: IMPERSONATION_TTL_MS / 1000,
+  })
+
+  await writeAudit({
+    userId: adminUserId,
+    impersonatedBy: adminUserId,
+    entityType: 'Exploitant',
+    entityId: targetExploitantId,
+    action: AuditAction.IMPERSONATE_START,
+  })
+
+  redirect(`/${locale}`)
+}
+
+/**
+ * Clears the impersonation cookie and emits an `IMPERSONATE_STOP` audit row.
+ * Tolerant: if the cookie is already gone (e.g. expired) we just no-op,
+ * still redirect, and skip the audit write to avoid noise.
+ */
+export async function stopImpersonation(locale: string): Promise<void> {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session?.user) throw new UnauthorizedError()
+
+  const store = await cookies()
+  const existing = store.get(IMPERSONATION_COOKIE_NAME)?.value
+  const claim = verifyImpersonationCookie(existing)
+
+  store.delete(IMPERSONATION_COOKIE_NAME)
+
+  if (claim && claim.adminUserId === session.user.id) {
+    await writeAudit({
+      userId: session.user.id,
+      impersonatedBy: session.user.id,
+      entityType: 'Exploitant',
+      entityId: claim.targetExploitantId,
+      action: AuditAction.IMPERSONATE_STOP,
+    })
+  }
+
+  redirect(`/${locale}/admin`)
+}

--- a/lib/auth/impersonation-cookie.ts
+++ b/lib/auth/impersonation-cookie.ts
@@ -1,0 +1,92 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+/**
+ * HMAC-signed cookie that proves an ADMIN_CALPAX has elected to view a
+ * given exploitant's tenant. The cookie carries:
+ *   - the admin's userId (so we can reject a cookie injected from elsewhere)
+ *   - the target exploitantId (the tenant we'll swap into the request context)
+ *   - the target's display name (avoids a DB lookup in the layout banner —
+ *     name may go stale within the 4h TTL if the exploitant is renamed,
+ *     acceptable trade-off for keeping `adminDb` out of every request)
+ *   - an absolute expiry (Date.now() at write + TTL)
+ *
+ * We do NOT trust the cookie alone: `requireAuth` re-checks that the
+ * current Better Auth session belongs to the same user AND still has the
+ * ADMIN_CALPAX role before honouring it.
+ *
+ * Format: `${base64url(payload)}.${base64url(hmac(secret, b64Payload))}`
+ * Payload: JSON `{ adminUserId, targetExploitantId, targetName, exp }`
+ */
+export const IMPERSONATION_COOKIE_NAME = 'cpx-impersonate-exploitant'
+export const IMPERSONATION_TTL_MS = 4 * 60 * 60 * 1000 // 4 hours
+
+export type ImpersonationClaim = {
+  adminUserId: string
+  targetExploitantId: string
+  targetName: string
+}
+
+type Payload = ImpersonationClaim & { exp: number }
+
+function getSecret(): string {
+  const s = process.env.BETTER_AUTH_SECRET ?? process.env.AUTH_SECRET
+  if (!s) throw new Error('BETTER_AUTH_SECRET missing — cannot sign impersonation cookie')
+  return s
+}
+
+export function signImpersonationCookie(
+  adminUserId: string,
+  targetExploitantId: string,
+  targetName: string,
+): string {
+  const payload: Payload = {
+    adminUserId,
+    targetExploitantId,
+    targetName,
+    exp: Date.now() + IMPERSONATION_TTL_MS,
+  }
+  const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  const sig = createHmac('sha256', getSecret()).update(encoded).digest('base64url')
+  return `${encoded}.${sig}`
+}
+
+export function verifyImpersonationCookie(
+  cookieValue: string | undefined,
+): ImpersonationClaim | null {
+  if (!cookieValue) return null
+
+  const dotIndex = cookieValue.lastIndexOf('.')
+  if (dotIndex <= 0) return null
+
+  const encoded = cookieValue.slice(0, dotIndex)
+  const sig = cookieValue.slice(dotIndex + 1)
+  if (!encoded || !sig) return null
+
+  const expected = createHmac('sha256', getSecret()).update(encoded).digest('base64url')
+  const sigBuf = Buffer.from(sig)
+  const expectedBuf = Buffer.from(expected)
+  if (sigBuf.length !== expectedBuf.length) return null
+  if (!timingSafeEqual(sigBuf, expectedBuf)) return null
+
+  let parsed: Payload
+  try {
+    parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString())
+  } catch {
+    return null
+  }
+  if (
+    typeof parsed?.adminUserId !== 'string' ||
+    typeof parsed?.targetExploitantId !== 'string' ||
+    typeof parsed?.targetName !== 'string' ||
+    typeof parsed?.exp !== 'number'
+  ) {
+    return null
+  }
+  if (Date.now() > parsed.exp) return null
+
+  return {
+    adminUserId: parsed.adminUserId,
+    targetExploitantId: parsed.targetExploitantId,
+    targetName: parsed.targetName,
+  }
+}

--- a/lib/auth/requireAuth.ts
+++ b/lib/auth/requireAuth.ts
@@ -1,7 +1,11 @@
 import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { runWithContext } from '@/lib/context'
 import { UnauthorizedError } from '@/lib/errors'
+import {
+  IMPERSONATION_COOKIE_NAME,
+  verifyImpersonationCookie,
+} from '@/lib/auth/impersonation-cookie'
 import type { UserRole } from '@/lib/context'
 
 export async function requireAuth<T>(fn: () => Promise<T>): Promise<T> {
@@ -12,13 +16,29 @@ export async function requireAuth<T>(fn: () => Promise<T>): Promise<T> {
   if (!session?.user) throw new UnauthorizedError()
 
   const user = session.user as Record<string, unknown>
-  const exploitantId = user.exploitantId as string
+  const sessionExploitantId = user.exploitantId as string
   // Least-privilege fallback: `User.role` is `UserRole NOT NULL` in Prisma
   // so the DB can't return null, but a session claim without a role (race
   // condition, legacy cookie) still falls through here. Defaulting to
   // EQUIPIER keeps the user locked out of elevated pages until the claim
   // is resolved, matching the sidebar default from issue #35.
-  const role = (user.role as string) ?? 'EQUIPIER'
+  const role = ((user.role as string) ?? 'EQUIPIER') as UserRole
+
+  // Exploitant-level impersonation (#59) — an ADMIN_CALPAX with a valid
+  // signed cookie pointing at a target tenant runs every subsequent request
+  // as if they were inside that tenant. The cookie is validated against the
+  // currently authenticated session: a stolen or replayed cookie targeting
+  // a different admin is rejected here.
+  let exploitantId = sessionExploitantId
+  let impersonatedBy: string | undefined
+  if (role === 'ADMIN_CALPAX') {
+    const cookieStore = await cookies()
+    const claim = verifyImpersonationCookie(cookieStore.get(IMPERSONATION_COOKIE_NAME)?.value)
+    if (claim && claim.adminUserId === session.user.id) {
+      exploitantId = claim.targetExploitantId
+      impersonatedBy = session.user.id
+    }
+  }
 
   // ADMIN_CALPAX can operate without a tenant (super-admin actions use adminDb).
   // Today the DB schema enforces exploitantId on all users, but this guard
@@ -31,7 +51,8 @@ export async function requireAuth<T>(fn: () => Promise<T>): Promise<T> {
     {
       userId: session.user.id,
       exploitantId,
-      role: role as UserRole,
+      role,
+      impersonatedBy,
     },
     fn,
   ) as Promise<T>

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,7 @@
 {
   "impersonation": {
     "connectedAs": "Viewing as",
+    "connectedAsExploitant": "Viewing data for",
     "exit": "Exit"
   },
   "common": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,6 +1,7 @@
 {
   "impersonation": {
     "connectedAs": "Connecté en tant que",
+    "connectedAsExploitant": "Vous consultez les données de",
     "exit": "Revenir"
   },
   "common": {

--- a/prisma/migrations/20260424214503_audit_action_impersonation/migration.sql
+++ b/prisma/migrations/20260424214503_audit_action_impersonation/migration.sql
@@ -1,0 +1,6 @@
+-- #59: explicit audit trail for ADMIN_CALPAX exploitant impersonation.
+-- Both events are emitted by lib/actions/impersonation.ts. The rows carry
+-- userId = the admin's id and `entityId` = the target exploitantId.
+
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'IMPERSONATE_START';
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'IMPERSONATE_STOP';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -233,6 +233,8 @@ enum AuditAction {
   ACCOUNT_LOCKED
   EXPORT_PII
   ANONYMIZE_PII
+  IMPERSONATE_START
+  IMPERSONATE_STOP
 }
 
 enum TypePlannif {

--- a/tests/unit/impersonation-cookie.spec.ts
+++ b/tests/unit/impersonation-cookie.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Impersonation cookie verifies the #59 sign/verify primitives:
+ *
+ *  - HMAC-signed cookie roundtrip (sign → verify yields the original claim)
+ *  - Tampered, mis-signed, or expired cookies fail verification
+ *  - The cookie binds the admin userId, target exploitant, and display name
+ *
+ * The full server-action flow (set cookie → redirect → next request runs
+ * with swapped exploitantId) requires a Next.js request lifecycle and is
+ * validated manually before release (see PR test plan).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createHmac } from 'node:crypto'
+import {
+  IMPERSONATION_COOKIE_NAME,
+  IMPERSONATION_TTL_MS,
+  signImpersonationCookie,
+  verifyImpersonationCookie,
+} from '@/lib/auth/impersonation-cookie'
+
+const ORIG_SECRET = process.env.BETTER_AUTH_SECRET
+const NAME = 'Cameron Balloons (FR.DEC.059)'
+
+describe('impersonation cookie', () => {
+  beforeEach(() => {
+    process.env.BETTER_AUTH_SECRET = 'test-impersonation-secret'
+  })
+
+  afterEach(() => {
+    if (ORIG_SECRET === undefined) delete process.env.BETTER_AUTH_SECRET
+    else process.env.BETTER_AUTH_SECRET = ORIG_SECRET
+    vi.useRealTimers()
+  })
+
+  it('exposes the canonical cookie name', () => {
+    // Hardcoded contract — layout + requireAuth + actions all reference it
+    // by string, so a rename here would silently break impersonation.
+    expect(IMPERSONATION_COOKIE_NAME).toBe('cpx-impersonate-exploitant')
+  })
+
+  it('signs and verifies a cookie roundtrip', () => {
+    const cookie = signImpersonationCookie('admin-123', 'expl-cameron', NAME)
+    const claim = verifyImpersonationCookie(cookie)
+    expect(claim).not.toBeNull()
+    expect(claim?.adminUserId).toBe('admin-123')
+    expect(claim?.targetExploitantId).toBe('expl-cameron')
+    expect(claim?.targetName).toBe(NAME)
+  })
+
+  it('rejects an undefined / empty cookie', () => {
+    expect(verifyImpersonationCookie(undefined)).toBeNull()
+    expect(verifyImpersonationCookie('')).toBeNull()
+  })
+
+  it('rejects a malformed cookie (no signature)', () => {
+    expect(verifyImpersonationCookie('garbage')).toBeNull()
+    expect(verifyImpersonationCookie('a.b')).toBeNull()
+  })
+
+  it('rejects a cookie signed with a different secret', () => {
+    const cookie = signImpersonationCookie('admin-123', 'expl-cameron', NAME)
+    process.env.BETTER_AUTH_SECRET = 'a-different-secret-altogether'
+    expect(verifyImpersonationCookie(cookie)).toBeNull()
+  })
+
+  it('rejects a cookie whose payload was tampered while keeping the original signature', () => {
+    const cookie = signImpersonationCookie('admin-123', 'expl-cameron', NAME)
+    const dot = cookie.lastIndexOf('.')
+    const sig = cookie.slice(dot + 1)
+    // Replace the payload with one targeting a DIFFERENT exploitant; the
+    // original signature was computed over the original payload bytes, so
+    // verification must fail.
+    const fakePayload = JSON.stringify({
+      adminUserId: 'admin-123',
+      targetExploitantId: 'expl-attacker-target',
+      targetName: 'attacker',
+      exp: Date.now() + IMPERSONATION_TTL_MS,
+    })
+    const tampered = `${Buffer.from(fakePayload).toString('base64url')}.${sig}`
+    expect(verifyImpersonationCookie(tampered)).toBeNull()
+  })
+
+  it('rejects a cookie whose payload is not valid JSON', () => {
+    // Simulate a cookie where the encoded payload decodes to non-JSON. We
+    // sign the malformed payload so the signature itself is valid — only
+    // the JSON.parse step should fail.
+    const fakePayload = 'not-json'
+    const encoded = Buffer.from(fakePayload).toString('base64url')
+    // Sign the malformed payload with the same secret so the signature is
+    // valid — only the JSON.parse step inside verify should fail.
+    const sig = createHmac('sha256', process.env.BETTER_AUTH_SECRET!)
+      .update(encoded)
+      .digest('base64url')
+    const cookie = `${encoded}.${sig}`
+    expect(verifyImpersonationCookie(cookie)).toBeNull()
+  })
+
+  it('rejects an expired cookie', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    const cookie = signImpersonationCookie('admin-123', 'expl-cameron', NAME)
+
+    // Move the clock past the TTL.
+    vi.setSystemTime(new Date(Date.now() + IMPERSONATION_TTL_MS + 1))
+    expect(verifyImpersonationCookie(cookie)).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #59. Le lien "Se connecter en tant que" sur le dashboard super-admin était inerte — il pointait vers `/?impersonate=…` mais aucun handler ne récupérait le query param. Cette PR met en place le flow complet.

## Mécanisme

Cookie signé + zéro middleware, swap au niveau `requireAuth` :

1. ADMIN_CALPAX clique "Impersonate" sur une ligne → form post vers `startImpersonation(exploitantId, locale)` (server action)
2. L'action valide session + role server-side, snapshot le nom d'affichage du target, signe `{ adminUserId, targetExploitantId, targetName, exp }` en HMAC-SHA256 avec `BETTER_AUTH_SECRET`, pose le cookie `cpx-impersonate-exploitant` (HttpOnly, Lax, 4h)
3. Audit row `IMPERSONATE_START` avant le redirect
4. À chaque requête suivante, `requireAuth` lit le cookie via `verifyImpersonationCookie`, **revérifie** que `adminUserId` matche la session Better Auth courante, swap `exploitantId` + pose `impersonatedBy = admin.userId` dans le contexte ALS. L'audit-extension utilise déjà `impersonatedBy` → toutes les écritures CRUD pendant l'impersonation portent l'ID de l'admin.
5. Le banner du layout lit le cookie (pas de DB hit — nom snapshotté dans le payload) et rend `<ImpersonationBanner kind="exploitant">` avec un bouton "Revenir" qui post `stopImpersonation`
6. `stopImpersonation` supprime le cookie et écrit `IMPERSONATE_STOP`

## Pourquoi un cookie plutôt qu'une colonne session

Better Auth ne se prête pas à des extensions de session arbitraires, et on veut que le swap d'exploitant soit indépendant de l'impersonation user-level (admin plugin → `session.session.impersonatedBy`). Cookie séparé = on peut ajouter/retirer l'impersonation tenant sans toucher au schéma auth.

## Garanties sécurité

- Cookie HMAC-signé avec `BETTER_AUTH_SECRET`, tampering rejeté via timing-safe compare
- Chaque requête revalide que le `adminUserId` du cookie matche la session courante — un cookie volé réutilisé sur un autre compte est silencieusement ignoré
- Role rechecké à chaque requête : un admin rétrogradé en GERANT pendant qu'il impersone perd le swap immédiatement
- TTL 4h : limite l'impact d'une fuite
- Audit trail complet via `IMPERSONATE_START` / `IMPERSONATE_STOP`

## Fichiers

**Nouveaux** :
- `lib/auth/impersonation-cookie.ts` — sign/verify
- `lib/admin/impersonation-actions.ts` — actions start/stop (dans `lib/admin/` pour respecter la règle ESLint sur `adminDb`)
- Migration `20260424214503_audit_action_impersonation` — enum values
- `tests/unit/impersonation-cookie.spec.ts` — 8 tests (roundtrip, mis-signed, tampered, expired, malformed JSON, empty inputs)

**Modifiés** :
- `prisma/schema.prisma` — `AuditAction` enum
- `lib/auth/requireAuth.ts` — lecture cookie + override
- `app/[locale]/admin/page.tsx` — Link → form server action
- `components/impersonation-banner.tsx` — prop `kind` (`'user'` | `'exploitant'`)
- `app/[locale]/(app)/layout.tsx` — détecte les 2 flavours d'impersonation, exploitant prend précédence
- `messages/{fr,en}.json` — clé `impersonation.connectedAsExploitant`

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — aucun nouveau warning
- [x] `pnpm test` — 143/143 pass
- [ ] CI : migrate + integration + build verts
- [ ] **Manuel post-merge** :
  - ADMIN_CALPAX clique Impersonate → banner s'affiche avec nom exploitant
  - Données vols/billets/pilotes reflètent le tenant cible
  - "Revenir" → cookie supprimé, retour `/admin`
  - AuditLog : `IMPERSONATE_START` + `IMPERSONATE_STOP` rows présentes

## Risques

- **Migration enum** : `ALTER TYPE ADD VALUE IF NOT EXISTS` — additif, safe
- **Cookie name** : un changement futur du nom casserait silencieusement l'impersonation. Test garde-fou ajouté (`exposes the canonical cookie name`)

https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR)_