### PR TITLE
review: BilletTag tenant isolation + audit log severity + dedupe date helpers

### DIFF
--- a/app/[locale]/(app)/vols/[id]/organiser/page.tsx
+++ b/app/[locale]/(app)/vols/[id]/organiser/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { db } from '@/lib/db'
+import { formatDateLong } from '@/lib/format'
 import { safeDecryptInt } from '@/lib/crypto'
 import { calculerDevisMasse } from '@/lib/vol/devis-masse'
 import { parseQteGazFromConfig } from '@/lib/vol/parse-config-gaz'
@@ -24,15 +25,6 @@ import { BilletAssignCard } from '@/components/billet-assign-card'
 
 type Props = {
   params: Promise<{ locale: string; id: string }>
-}
-
-function formatDateLong(date: Date): string {
-  return date.toLocaleDateString('fr-FR', {
-    weekday: 'long',
-    day: '2-digit',
-    month: 'long',
-    year: 'numeric',
-  })
 }
 
 export default async function OrganiserVolPage({ params }: Props) {
@@ -119,7 +111,7 @@ export default async function OrganiserVolPage({ params }: Props) {
 
         {/* Session info */}
         <p className="text-sm text-muted-foreground">
-          {formatDateLong(vol.date)} — {t(`creneau.${vol.creneau}`)}
+          {formatDateLong(vol.date, locale)} — {t(`creneau.${vol.creneau}`)}
           {isMultiBallon && ` — ${sessionVols.length} ballons`}
         </p>
 

--- a/components/my-sessions-card.tsx
+++ b/components/my-sessions-card.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
 import { toast } from 'sonner'
 import { Loader2, Monitor, Smartphone } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { revokeMySession, type MySession } from '@/lib/actions/session'
+import { formatDateTimeShort } from '@/lib/format'
 
 type Props = {
   sessions: MySession[]
@@ -34,6 +35,7 @@ function deviceLabel(ua: string | null): { label: string; icon: typeof Monitor }
 
 export function MySessionsCard({ sessions }: Props) {
   const t = useTranslations('profil.sessions')
+  const locale = useLocale()
   const [pending, startTransition] = useTransition()
   const [revokingId, setRevokingId] = useState<string | null>(null)
   const [revoked, setRevoked] = useState<Set<string>>(new Set())
@@ -50,13 +52,6 @@ export function MySessionsCard({ sessions }: Props) {
         toast.success(t('revokeSuccess'))
         setRevoked((prev) => new Set(prev).add(sessionId))
       }
-    })
-  }
-
-  function formatDate(date: Date) {
-    return new Date(date).toLocaleString('fr-FR', {
-      dateStyle: 'short',
-      timeStyle: 'short',
     })
   }
 
@@ -89,7 +84,7 @@ export function MySessionsCard({ sessions }: Props) {
                       )}
                     </div>
                     <p className="text-xs text-muted-foreground mt-0.5">
-                      {s.ipAddress ?? '—'} · {formatDate(s.createdAt)}
+                      {s.ipAddress ?? '—'} · {formatDateTimeShort(s.createdAt, locale)}
                     </p>
                   </div>
                   {!s.isCurrent && (

--- a/lib/actions/tag.ts
+++ b/lib/actions/tag.ts
@@ -33,9 +33,23 @@ export async function deleteTag(tagId: string): Promise<{ error?: string }> {
   })
 }
 
+// BilletTag is UNTENANTED (join table without exploitantId column), so the
+// tenant extension cannot auto-scope it. Validate that both ids belong to the
+// caller's tenant via tenant-scoped reads before touching the join row.
+async function assertBothInTenant(billetId: string, tagId: string): Promise<boolean> {
+  const [billet, tag] = await Promise.all([
+    db.billet.findUnique({ where: { id: billetId }, select: { id: true } }),
+    db.tag.findUnique({ where: { id: tagId }, select: { id: true } }),
+  ])
+  return billet !== null && tag !== null
+}
+
 export async function addTagToBillet(billetId: string, tagId: string): Promise<{ error?: string }> {
   return requireAuth(async () => {
     requireRole('ADMIN_CALPAX', 'GERANT')
+    if (!(await assertBothInTenant(billetId, tagId))) {
+      return { error: 'Billet ou tag introuvable' }
+    }
     const { basePrisma } = await import('@/lib/db/base')
     try {
       await basePrisma.billetTag.create({ data: { billetId, tagId } })
@@ -53,6 +67,9 @@ export async function removeTagFromBillet(
 ): Promise<{ error?: string }> {
   return requireAuth(async () => {
     requireRole('ADMIN_CALPAX', 'GERANT')
+    if (!(await assertBothInTenant(billetId, tagId))) {
+      return { error: 'Billet ou tag introuvable' }
+    }
     const { basePrisma } = await import('@/lib/db/base')
     await basePrisma.billetTag.delete({
       where: { billetId_tagId: { billetId, tagId } },

--- a/lib/db/audit-extension.ts
+++ b/lib/db/audit-extension.ts
@@ -1,6 +1,7 @@
 import { Prisma, AuditAction } from '@prisma/client'
 import { basePrisma } from './base'
 import { tryGetContext } from '@/lib/context'
+import { logger } from '@/lib/logger'
 
 function modelAccessor(model: string): string {
   return model.charAt(0).toLowerCase() + model.slice(1)
@@ -132,7 +133,12 @@ export const auditExtension = Prisma.defineExtension({
             })
           }
         } catch (err) {
-          console.warn('audit-extension: failed to write audit row', err)
+          // Audit-trail integrity matters for RGPD compliance — surface as
+          // error so it shows up in monitoring instead of silently dropping.
+          logger.error(
+            { err, model, operation, exploitantId, userId },
+            'audit-extension: failed to write audit row',
+          )
         }
 
         return result


### PR DESCRIPTION
## Summary

Mixed-axis review pass (simplification, code quality, security/RGPD). Three small, targeted fixes — no behavioural changes for legitimate users.

### 🔒 Security / RGPD — `lib/actions/tag.ts`
`BilletTag` is in the `UNTENANTED` set in `lib/db/tenant-extension.ts` (it's a join table without an `exploitantId` column), so the tenant extension cannot auto-scope it. The existing `addTagToBillet` / `removeTagFromBillet` server actions used `basePrisma.billetTag.create({ data: { billetId, tagId } })` with no ownership check beyond `requireRole('ADMIN_CALPAX', 'GERANT')`.

**Impact:** a `GERANT` of tenant A who knows or guesses a `billetId` from tenant B could attach their tag to tenant B's billet (and vice versa for removal). Doesn't leak passenger data, but it breaks tenant isolation invariants and would surface another tenant's billet id in the join row — a multi-tenant SaaS contract violation.

**Fix:** `assertBothInTenant()` does two tenant-scoped reads via `db.billet.findUnique` / `db.tag.findUnique` (the tenant extension returns `null` for cross-tenant ids) before the unscoped `basePrisma.billetTag` write/delete. Returns `{ error: 'Billet ou tag introuvable' }` on mismatch, matching the existing error-shape contract.

### 🧰 Quality — `lib/db/audit-extension.ts`
Audit-write failures were being swallowed by `console.warn`, which doesn't reach pino/Sentry in production. RGPD compliance hinges on the audit trail being trustworthy — a silent drop is the worst failure mode.

Promoted to `logger.error({ err, model, operation, exploitantId, userId }, 'audit-extension: failed to write audit row')`. Same control flow, just observable now.

### ✂️ Simplify — date helpers
- `app/[locale]/(app)/vols/[id]/organiser/page.tsx` — dropped a local `formatDateLong` re-implementation, now imports from `lib/format` and passes `locale` (was hardcoded to `fr-FR`).
- `components/my-sessions-card.tsx` — dropped a local `formatDate` (`dateStyle: 'short', timeStyle: 'short'`), now uses `formatDateTimeShort(date, useLocale())` — same wire format, but locale-aware instead of hardcoded `fr-FR`.

---

## Items intentionally deferred (worth a follow-up issue)

These came up in the review but didn't land here — either too large for one PR or needing a design call.

### Code quality
- **Date `toLocaleString('fr-FR')` in 5 admin/audit views** (`audit-client.tsx` ×2, `admin/sessions/page.tsx`, `admin/users/page.tsx`) — uses the default `toLocaleString` (with seconds), not `formatDateTimeShort`. Switching changes display format slightly, so I left it for a deliberate decision.
- **`grid grid-cols-2` without a mobile breakpoint** appears ~30× across `app/`. Most are inside billet/vol forms — needs a UX pass to decide whether to stack on `< sm` or keep side-by-side.
- **FormData → object extractors** (`extractBilletData`, `extractPiloteData`, `mapPassagerForCreate`) repeat the same pattern. A single `lib/actions/form-parse.ts` helper would save ~30 LOC but touches a lot of files.
- **Action return types** drift between `Promise<{ error?: string }>` and ad-hoc shapes — a discriminated `ActionResult<T>` would make form `useTransition` flows uniform.

### Security / RGPD (lower priority)
- `lib/actions/admin.ts:176-179` logs `{ err, ...}` without scrubbing the error message. Pino's redact paths cover header/cookie/password/token but not nested error strings — worth adding a generic `err.message` sanitizer if errors can echo user input.

### UX / Design proposals (no code yet)
1. **Cockpit dashboard density** — `UpcomingFlightsTable` and `FleetRow` both have their own date helpers (`formatDateShort`, weekday + day + month-short). Consider promoting to `lib/format.ts` as `formatDateWeekdayShort()` and `formatDateDayMonthShort()` so cockpit looks identical to the rest of the app and supports `en` for the future EU market.
2. **`window.confirm()` in `MySessionsCard.handleRevoke`** — replace with a shadcn `AlertDialog`. Native confirm dialogs feel out of place in a polished SaaS, especially on mobile where the styling jumps.
3. **`<Select>` aria-labels** in `vol-create-form.tsx` and similar — Radix `<SelectTrigger>` inherits its accessible name from a sibling `<Label>` *only* when wired through a form library. Audit forms that don't use react-hook-form to make sure each Select has either a `<Label htmlFor>` or `aria-label`.
4. **Suspense boundaries** — every `app/[locale]/(app)/*/page.tsx` is `async` with no `loading.tsx` sibling. Adding granular `<Suspense>` around the heaviest queries (vols/organiser, dashboard cockpit) would meaningfully cut TTFB on the operator's day-J view.
5. **Audit log UI** — admin `audit-client.tsx` shows raw JSON for `before`/`after`. For `UPDATE` rows where `field` is set, a side-by-side `before → after` cell would be far more scannable than `JSON.stringify`.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — only pre-existing warnings (unused `DevisMasseLive` was already there before this PR)
- [x] `pnpm test` — 143/143 unit tests pass
- [ ] Manual: try `addTagToBillet` with a foreign-tenant `billetId` (smoke test for the security fix) — recommend an integration test in a follow-up
- [ ] Manual: trigger a forced audit-write failure (e.g. drop the `audit_log` table in dev) and confirm it shows up in `logger.error` output

https://claude.ai/code/session_01YA7r8C8FHQNY61DeyAH1Rj

---
_Generated by [Claude Code](https://claude.ai/code/session_01YA7r8C8FHQNY61DeyAH1Rj)_