### PR TITLE
ux(#88): mobile responsive on grid-cols-2 forms + detail pages

### DIFF
--- a/app/[locale]/(app)/ballons/[id]/edit/ballon-edit-form.tsx
+++ b/app/[locale]/(app)/ballons/[id]/edit/ballon-edit-form.tsx
@@ -109,7 +109,7 @@ export function BallonEditForm({ locale, ballonId, ballon, performanceChart }: P
               required
             />
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label htmlFor="nbPassagerMax" className={labelClassName}>
                 {t('fields.nbPassagerMax')} *
@@ -154,7 +154,7 @@ export function BallonEditForm({ locale, ballonId, ballon, performanceChart }: P
             />
             <p className="text-xs text-muted-foreground">{t('fields.manexAnnexRefHint')}</p>
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label htmlFor="mtom" className={labelClassName}>
                 {t('fields.mtom')}

--- a/app/[locale]/(app)/ballons/[id]/page.tsx
+++ b/app/[locale]/(app)/ballons/[id]/page.tsx
@@ -65,7 +65,7 @@ export default async function BallonDetailPage({ params }: Props) {
           <CardHeader>
             <CardTitle className="text-base">Informations générales</CardTitle>
           </CardHeader>
-          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
+          <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             <div>
               <p className="text-xs uppercase tracking-wider text-muted-foreground">
                 {t('fields.immatriculation')}
@@ -127,7 +127,7 @@ export default async function BallonDetailPage({ params }: Props) {
           <CardHeader>
             <CardTitle className="text-base">CAMO &amp; Navigabilité</CardTitle>
           </CardHeader>
-          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
+          <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             {ballon.camoOrganisme && (
               <div>
                 <p className="text-xs uppercase tracking-wider text-muted-foreground">

--- a/app/[locale]/(app)/ballons/new/page.tsx
+++ b/app/[locale]/(app)/ballons/new/page.tsx
@@ -55,7 +55,7 @@ export default async function BallonNewPage({ params }: Props) {
                 <Label htmlFor="volumeM3">{t('fields.volumeM3')} *</Label>
                 <Input id="volumeM3" name="volumeM3" type="number" min="1" required />
               </div>
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-1">
                   <Label htmlFor="nbPassagerMax">{t('fields.nbPassagerMax')} *</Label>
                   <Input id="nbPassagerMax" name="nbPassagerMax" type="number" min="1" required />
@@ -73,7 +73,7 @@ export default async function BallonNewPage({ params }: Props) {
                 <Input id="manexAnnexRef" name="manexAnnexRef" required />
                 <p className="text-xs text-muted-foreground">{t('fields.manexAnnexRefHint')}</p>
               </div>
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-1">
                   <Label htmlFor="mtom">{t('fields.mtom')}</Label>
                   <Input id="mtom" name="mtom" type="number" min="0" />

--- a/app/[locale]/(app)/billets/[id]/edit/billet-form.tsx
+++ b/app/[locale]/(app)/billets/[id]/edit/billet-form.tsx
@@ -144,7 +144,7 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
               </SelectContent>
             </Select>
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label
                 htmlFor="payeurPrenom"
@@ -214,7 +214,7 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
               defaultValue={defaultValues?.payeurAdresse ?? ''}
             />
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label
                 htmlFor="payeurCp"
@@ -286,7 +286,7 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
             />
           </div>
           {showDates && (
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div className="space-y-1">
                 <Label
                   htmlFor="dateVolDeb"
@@ -317,7 +317,7 @@ export function BilletForm({ locale, billetId, defaultValues, defaultPassagers }
               </div>
             </div>
           )}
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label
                 htmlFor="dateValidite"

--- a/app/[locale]/(app)/billets/[id]/page.tsx
+++ b/app/[locale]/(app)/billets/[id]/page.tsx
@@ -139,7 +139,7 @@ export default async function BilletDetailPage({ params }: Props) {
           <CardHeader>
             <CardTitle className="text-base">Payeur</CardTitle>
           </CardHeader>
-          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
+          <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             <div>
               <p className="text-xs uppercase tracking-wider text-muted-foreground">
                 {tBillets('fields.payeurPrenom')}
@@ -185,7 +185,7 @@ export default async function BilletDetailPage({ params }: Props) {
           <CardHeader>
             <CardTitle className="text-base">Planification</CardTitle>
           </CardHeader>
-          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
+          <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             <div>
               <p className="text-xs uppercase tracking-wider text-muted-foreground">
                 {tBillets('fields.typePlannif')}

--- a/app/[locale]/(app)/pilotes/[id]/edit/pilote-edit-form.tsx
+++ b/app/[locale]/(app)/pilotes/[id]/edit/pilote-edit-form.tsx
@@ -61,7 +61,7 @@ export function PiloteEditForm({ locale, piloteId, pilote }: Props) {
           <CardTitle className="text-base">Identite</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label htmlFor="prenom" className={labelClassName}>
                 {t('fields.prenom')} *

--- a/app/[locale]/(app)/pilotes/[id]/page.tsx
+++ b/app/[locale]/(app)/pilotes/[id]/page.tsx
@@ -63,7 +63,7 @@ export default async function PiloteDetailPage({ params }: Props) {
           <CardHeader>
             <CardTitle className="text-base">Identité</CardTitle>
           </CardHeader>
-          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
+          <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             {pilote.email && (
               <div>
                 <p className="text-xs uppercase tracking-wider text-muted-foreground">
@@ -95,7 +95,7 @@ export default async function PiloteDetailPage({ params }: Props) {
           <CardHeader>
             <CardTitle className="text-base">Licence BFCL</CardTitle>
           </CardHeader>
-          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
+          <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             <div>
               <p className="text-xs uppercase tracking-wider text-muted-foreground">
                 {t('fields.licenceBfcl')}
@@ -127,7 +127,7 @@ export default async function PiloteDetailPage({ params }: Props) {
           <CardHeader>
             <CardTitle className="text-base">{t('sections.classesBfcl')}</CardTitle>
           </CardHeader>
-          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
+          <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             <div>
               <p className="text-xs uppercase tracking-wider text-muted-foreground">
                 {t('fields.classesBfcl')}

--- a/app/[locale]/(app)/pilotes/new/page.tsx
+++ b/app/[locale]/(app)/pilotes/new/page.tsx
@@ -42,7 +42,7 @@ export default async function PiloteNewPage({ params }: Props) {
               <CardTitle className="text-base">Identité</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-1">
                   <Label htmlFor="prenom">{t('fields.prenom')} *</Label>
                   <Input id="prenom" name="prenom" required />

--- a/app/[locale]/(app)/profil/page.tsx
+++ b/app/[locale]/(app)/profil/page.tsx
@@ -44,7 +44,7 @@ export default async function ProfilPage() {
             <CardTitle className="text-base">{t('identity')}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div>
                 <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   {t('name')}
@@ -74,7 +74,7 @@ export default async function ProfilPage() {
             <CardTitle className="text-base">{t('exploitant')}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div>
                 <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   {t('exploitantName')}

--- a/app/[locale]/(app)/settings/page.tsx
+++ b/app/[locale]/(app)/settings/page.tsx
@@ -99,7 +99,7 @@ export default async function SettingsPage() {
                 <Label htmlFor="adresse">{t('fields.adresse')}</Label>
                 <Input id="adresse" name="adresse" defaultValue={exploitant.adresse ?? ''} />
               </div>
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-1">
                   <Label htmlFor="codePostal">{t('fields.codePostal')}</Label>
                   <Input
@@ -158,7 +158,7 @@ export default async function SettingsPage() {
               <CardTitle className="text-base">{t('meteoSection')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-1">
                   <Label htmlFor="meteoLatitude">{t('fields.meteoLatitude')}</Label>
                   <Input

--- a/app/[locale]/(app)/vols/[id]/post-vol/post-vol-form.tsx
+++ b/app/[locale]/(app)/vols/[id]/post-vol/post-vol-form.tsx
@@ -39,7 +39,7 @@ export function PostVolForm({ volId, locale }: Props) {
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Decollage */}
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label htmlFor="decoLieu">{t('postVol.decoLieu')} *</Label>
               <Input id="decoLieu" name="decoLieu" required />
@@ -51,7 +51,7 @@ export function PostVolForm({ volId, locale }: Props) {
           </div>
 
           {/* Atterrissage */}
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label htmlFor="atterLieu">{t('postVol.atterLieu')} *</Label>
               <Input id="atterLieu" name="atterLieu" required />
@@ -63,7 +63,7 @@ export function PostVolForm({ volId, locale }: Props) {
           </div>
 
           {/* Gaz et distance */}
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label htmlFor="gasConso">{t('postVol.gasConso')}</Label>
               <Input id="gasConso" name="gasConso" type="number" min="0" step="1" />

--- a/app/[locale]/(app)/vols/create/vol-create-form.tsx
+++ b/app/[locale]/(app)/vols/create/vol-create-form.tsx
@@ -155,7 +155,7 @@ export function VolCreateForm({
           <CardTitle className="text-base">Informations du vol</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label htmlFor="date" className={labelClassName}>
                 {t('fields.date')} *
@@ -236,7 +236,7 @@ export function VolCreateForm({
           <CardTitle className="text-base">Logistique</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {/* Equipier */}
             <div className="space-y-1">
               <Label className={labelClassName}>{t('fields.equipier')}</Label>
@@ -316,7 +316,7 @@ export function VolCreateForm({
             )}
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label htmlFor="configGaz" className={labelClassName}>
                 {t('fields.configGaz')}

--- a/components/paiement-form.tsx
+++ b/components/paiement-form.tsx
@@ -51,7 +51,7 @@ export function PaiementForm({ billetId, locale }: Props) {
   return (
     <form action={handleSubmit} className="border rounded p-4 space-y-3">
       {error && <div className="text-red-600 text-sm">{error}</div>}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <div>
           <Label className={labelClassName}>{t('fields.modePaiement')}</Label>
           <Select value={modePaiement} onValueChange={setModePaiement}>


### PR DESCRIPTION
Closes #88. **~30 occurrences** de `grid grid-cols-2` n'avaient aucun breakpoint mobile → sur téléphone (375px), les forms à 2 colonnes étaient écrasés avec labels qui débordent.

## Changements

Switch mécanique : `grid grid-cols-2 gap-X` → `grid grid-cols-1 gap-X sm:grid-cols-2` partout où c'est pertinent.

**13 fichiers, +28 / -28 lignes.**

### Forms (`gap-4`)
- `ballons` (new + edit) ×2
- `billets` (`billet-form.tsx`) ×4
- `pilotes` (new + edit) ×2
- `settings` ×2
- `vols/create` ×3
- `vols/[id]/post-vol-form` ×3

### Detail pages (`gap-x-8 gap-y-3 text-sm`)
- `ballons/[id]`, `billets/[id]`, `pilotes/[id]`, `profil`

### Components (`gap-3`)
- `paiement-form`

## Intentionnellement laissés

- `pilotes/{[id]/edit,new}` `grid-cols-2 gap-3` — grids de checkboxes (groupes A1-A4), labels courts OK sur mobile
- `vols/loading.tsx` — skeleton, fine
- `two-factor-card` backup codes — `abcde-fghij` (11 chars), fit en 2 colonnes mobile

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — aucun nouveau warning
- [x] `pnpm test` — 143/143 pass
- [ ] CI : build + integration verts
- [ ] **Manuel** : DevTools → 375px → vérifier que tous les forms et detail pages stackent en 1 col, et qu'à ≥640px ils repassent en 2 cols

## Risques

- Pas de migration, pas de logique modifiée — purement Tailwind
- Si un layout en aval comptait sur la dimension exacte d'un grid 2-col en mobile, il serait cassé. Très peu probable vu le pattern (Card content)

https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR)_