### PR TITLE
ux(#73, #92): empty-state hint + audit log diff UI for UPDATE rows

### DIFF
--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -356,7 +356,8 @@ export default async function HomePage({ params }: Props) {
         {vols.length === 0 ? (
           <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-sky-200 bg-card py-16 text-center">
             <Plane className="mb-4 h-12 w-12 text-sky-400" aria-hidden />
-            <p className="mb-4 text-sky-500">{t('noFlights')}</p>
+            <p className="mb-1 text-base font-medium text-sky-700">{t('noFlights')}</p>
+            <p className="mb-4 text-sm text-sky-500">{t('noFlightsHint')}</p>
             <Button asChild variant="outline">
               <Link href={`/${locale}/vols`}>{t('goToPlanning')}</Link>
             </Button>

--- a/app/[locale]/admin/audit/audit-client.tsx
+++ b/app/[locale]/admin/audit/audit-client.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState, useEffect, useMemo, useId } from 'react'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
+import { ArrowRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Table,
@@ -14,8 +15,9 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { fetchAdminAuditLogs } from '@/lib/actions/admin'
+import { formatDateTimeShort } from '@/lib/format'
 
-const ENTITY_TYPES = ['Ballon', 'Pilote', 'Billet', 'Passager', 'Paiement', 'Vol', 'AUTH']
+const ENTITY_TYPES = ['Ballon', 'Pilote', 'Billet', 'Passager', 'Paiement', 'Vol', 'Exploitant']
 const ACTIONS = [
   'CREATE',
   'UPDATE',
@@ -26,6 +28,10 @@ const ACTIONS = [
   'PASSWORD_RESET',
   'PASSWORD_CHANGED',
   'ACCOUNT_LOCKED',
+  'EXPORT_PII',
+  'ANONYMIZE_PII',
+  'IMPERSONATE_START',
+  'IMPERSONATE_STOP',
 ]
 
 type AuditLog = {
@@ -61,6 +67,7 @@ export function AdminAuditClient({
 }) {
   const t = useTranslations('audit')
   const ta = useTranslations('admin.audit')
+  const locale = useLocale()
   const [exploitantId, setExploitantId] = useState('')
   const [entityType, setEntityType] = useState('')
   const [action, setAction] = useState('')
@@ -91,14 +98,17 @@ export function AdminAuditClient({
     }
   }, [exploitantId, entityType, action, page])
 
-  function formatDate(date: Date) {
-    return new Date(date).toLocaleString('fr-FR')
-  }
-
   function formatJson(value: unknown): string {
-    if (value === null || value === undefined) return '--'
+    if (value === null || value === undefined) return '—'
     if (typeof value === 'string') return value
     return JSON.stringify(value)
+  }
+
+  /** True for UPDATE rows where the audit-extension recorded a single field
+   *  change (one row per modified field). For these we render the before /
+   *  after columns as a colour-coded inline diff rather than raw JSON. */
+  function isFieldDiff(log: AuditLog): boolean {
+    return log.action === 'UPDATE' && log.field !== null
   }
 
   const exploitantMap = useMemo(
@@ -202,9 +212,11 @@ export function AdminAuditClient({
             <TableBody>
               {logs.map((log) => (
                 <TableRow key={String(log.id)}>
-                  <TableCell className="text-xs">{formatDate(log.createdAt)}</TableCell>
                   <TableCell className="text-xs">
-                    {log.exploitantId ? (exploitantMap.get(log.exploitantId) ?? '--') : '--'}
+                    {formatDateTimeShort(log.createdAt, locale)}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {log.exploitantId ? (exploitantMap.get(log.exploitantId) ?? '—') : '—'}
                   </TableCell>
                   <TableCell className="text-xs">
                     {log.impersonatedBy ? (
@@ -212,7 +224,7 @@ export function AdminAuditClient({
                         {adminMap.get(log.impersonatedBy) ?? log.impersonatedBy.slice(0, 8)}
                       </Badge>
                     ) : (
-                      '--'
+                      '—'
                     )}
                   </TableCell>
                   <TableCell>
@@ -224,13 +236,32 @@ export function AdminAuditClient({
                   <TableCell>
                     <Badge>{log.action}</Badge>
                   </TableCell>
-                  <TableCell>{log.field ?? '--'}</TableCell>
-                  <TableCell className="max-w-32 truncate text-xs">
-                    {formatJson(log.beforeValue)}
-                  </TableCell>
-                  <TableCell className="max-w-32 truncate text-xs">
-                    {formatJson(log.afterValue)}
-                  </TableCell>
+                  <TableCell className="font-mono text-xs">{log.field ?? '—'}</TableCell>
+                  {isFieldDiff(log) ? (
+                    <TableCell colSpan={2} className="text-xs">
+                      <div className="flex items-center gap-2 font-mono">
+                        <span className="rounded bg-red-50 px-1.5 py-0.5 text-red-700 line-through">
+                          {formatJson(log.beforeValue)}
+                        </span>
+                        <ArrowRight
+                          className="h-3 w-3 shrink-0 text-muted-foreground"
+                          aria-hidden
+                        />
+                        <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-emerald-700">
+                          {formatJson(log.afterValue)}
+                        </span>
+                      </div>
+                    </TableCell>
+                  ) : (
+                    <>
+                      <TableCell className="max-w-32 truncate text-xs">
+                        {formatJson(log.beforeValue)}
+                      </TableCell>
+                      <TableCell className="max-w-32 truncate text-xs">
+                        {formatJson(log.afterValue)}
+                      </TableCell>
+                    </>
+                  )}
                 </TableRow>
               ))}
             </TableBody>

--- a/messages/en.json
+++ b/messages/en.json
@@ -715,6 +715,7 @@
   "dashboard": {
     "title": "Today's flights",
     "noFlights": "No flights today",
+    "noFlightsHint": "Enjoy a quiet day, or plan ahead.",
     "goToPlanning": "View planning",
     "flightCount": "{count, plural, one {# flight} other {# flights}}",
     "passengers": "passengers",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -715,6 +715,7 @@
   "dashboard": {
     "title": "Vols du jour",
     "noFlights": "Aucun vol aujourd'hui",
+    "noFlightsHint": "Profitez d'une journée tranquille, ou planifiez la suite.",
     "goToPlanning": "Voir le planning",
     "flightCount": "{count, plural, one {# vol} other {# vols}}",
     "passengers": "passagers",


### PR DESCRIPTION
Closes #73 et #92. Deux UX polish flagués dans les follow-ups de PR #83. Bundlés dans une seule PR (peu de risque, contextes UI proches).

## #73 — empty-state dashboard "no flights today"

Avant : juste "Aucun vol aujourd'hui" + bouton.
Après : ajout d'une ligne d'indication amicale en dessous.

```
✈️  Aucun vol aujourd'hui
    Profitez d'une journée tranquille, ou planifiez la suite.
    [Voir le planning]
```

EN : `Enjoy a quiet day, or plan ahead.`

## #92 — admin audit log diff UI

Pour les rows `UPDATE` où `field` est défini (le cas du diff field-level enregistré par l'audit-extension), les colonnes `before` / `after` sont fusionnées en une seule cellule avec un diff visuel inline :

```
| field | [old → new]                    |
| nom   | "Vieux nom" → "Nouveau nom"   |   ← rouge barré + flèche + vert
```

Pour les rows `CREATE` / `DELETE` (field null, payload complet), comportement inchangé : 2 cellules JSON tronquées.

## Bonus dans le même fichier

- **Date column** : `toLocaleString('fr-FR')` → `formatDateTimeShort(date, locale)` — locale-aware, plus de FR hardcodé (couvre une partie de #86)
- **ENTITY_TYPES** : `'AUTH'` (placeholder qui ne correspond à aucun entityType réel) → `'Exploitant'` (utilisé par les rows `IMPERSONATE_*`)
- **ACTIONS list** : ajout des 4 actions manquantes au filtre dropdown :
  - `EXPORT_PII` (#71)
  - `ANONYMIZE_PII` (#71)
  - `IMPERSONATE_START` (#82)
  - `IMPERSONATE_STOP` (#82)
- Cosmétique : `'--'` → `'—'` em-dash pour cohérence

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — aucun nouveau warning
- [x] `pnpm test` — 143/143 pass
- [ ] CI : build + integration verts
- [ ] **Manuel** :
  - `/fr` ou `/en` sans vol du jour → empty state avec hint
  - `/fr/admin/audit` → renommer un ballon → row UPDATE affiche `"Vieux" → "Nouveau"` en couleurs
  - Filter dropdown affiche bien les 4 actions ajoutées

## Risques

- Aucune migration, aucune dep, aucune logique modifiée
- Le `colSpan={2}` dans la table casse pas l'alignement (les UPDATE-with-field rows sont visuellement clairs)

https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbNAGtQvy73jALHHWHvQqR)_