### PR TITLE
review: simplify duplicates + a11y AlertDialog + audit redaction + auth secret guard

### DIFF
--- a/app/[locale]/(app)/audit/audit-client.tsx
+++ b/app/[locale]/(app)/audit/audit-client.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
 import { fetchAuditLogs } from '@/lib/actions/audit'
+import { formatDateTimeFr } from '@/lib/format'
 
 const ENTITY_TYPES = ['Ballon', 'Pilote', 'Billet', 'Passager', 'Paiement', 'Vol', 'AUTH']
 const ACTIONS = [
@@ -62,10 +63,6 @@ export function AuditClient() {
     void load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entityType, action, page])
-
-  function formatDate(date: Date) {
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   function formatJson(value: unknown): string {
     if (value === null || value === undefined) return '—'
@@ -136,7 +133,7 @@ export function AuditClient() {
           <TableBody>
             {logs.map((log) => (
               <TableRow key={String(log.id)}>
-                <TableCell className="text-xs">{formatDate(log.createdAt)}</TableCell>
+                <TableCell className="text-xs">{formatDateTimeFr(log.createdAt)}</TableCell>
                 <TableCell>
                   <Badge variant="outline">{log.entityType}</Badge>{' '}
                   <span className="text-xs text-muted-foreground">{log.entityId.slice(0, 8)}</span>

--- a/app/[locale]/(app)/ballons/[id]/journal/page.tsx
+++ b/app/[locale]/(app)/ballons/[id]/journal/page.tsx
@@ -16,26 +16,10 @@ import {
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 import { formatDateFr } from '@/lib/format'
-import type { StatutVol } from '@prisma/client'
+import { statutVolVariant } from '@/lib/ui'
 
 type Props = {
   params: Promise<{ locale: string; id: string }>
-}
-
-function statutVariant(statut: StatutVol): 'outline' | 'default' | 'secondary' | 'destructive' {
-  switch (statut) {
-    case 'PLANIFIE':
-    case 'CONFIRME':
-      return 'default'
-    case 'TERMINE':
-      return 'secondary'
-    case 'ARCHIVE':
-      return 'outline'
-    case 'ANNULE':
-      return 'destructive'
-    default:
-      return 'outline'
-  }
 }
 
 function truncate(text: string | null, max: number): string {
@@ -163,7 +147,7 @@ export default async function BallonJournalPage({ params }: Props) {
                         {vol.pilote.prenom} {vol.pilote.nom}
                       </TableCell>
                       <TableCell>
-                        <Badge variant={statutVariant(vol.statut)}>
+                        <Badge variant={statutVolVariant(vol.statut)}>
                           {tVols(`statut.${vol.statut}`)}
                         </Badge>
                       </TableCell>

--- a/app/[locale]/(app)/billets/[id]/page.tsx
+++ b/app/[locale]/(app)/billets/[id]/page.tsx
@@ -18,54 +18,16 @@ import {
 } from '@/components/ui/table'
 import { PaiementForm } from '@/components/paiement-form'
 import { cn } from '@/lib/utils'
-import { formatDateFr } from '@/lib/format'
-import type { StatutBillet, StatutPaiement } from '@prisma/client'
+import { formatDateFr, formatEuros } from '@/lib/format'
+import { statutBilletVariant, statutPaiementVariant } from '@/lib/ui'
 
 type Props = {
   params: Promise<{ locale: string; id: string }>
 }
 
-function formatEuros(euros: number): string {
-  return euros.toFixed(2) + ' EUR'
-}
-
 function formatDate(date: Date | null | undefined): string {
   if (!date) return '—'
   return formatDateFr(date)
-}
-
-function statutVariant(statut: StatutBillet): 'outline' | 'default' | 'secondary' | 'destructive' {
-  switch (statut) {
-    case 'EN_ATTENTE':
-      return 'outline'
-    case 'PLANIFIE':
-      return 'default'
-    case 'VOLE':
-      return 'secondary'
-    case 'ANNULE':
-    case 'REMBOURSE':
-    case 'EXPIRE':
-      return 'destructive'
-    default:
-      return 'outline'
-  }
-}
-
-function statutPaiementVariant(
-  statut: StatutPaiement,
-): 'outline' | 'default' | 'secondary' | 'destructive' {
-  switch (statut) {
-    case 'EN_ATTENTE':
-      return 'outline'
-    case 'SOLDE':
-      return 'default'
-    case 'PARTIEL':
-      return 'secondary'
-    case 'REMBOURSE':
-      return 'destructive'
-    default:
-      return 'outline'
-  }
 }
 
 export default async function BilletDetailPage({ params }: Props) {
@@ -103,7 +65,7 @@ export default async function BilletDetailPage({ params }: Props) {
               {tBillets('backToList')}
             </Link>
             <h1 className="text-3xl font-bold tracking-tight">{billet.reference}</h1>
-            <Badge variant={statutVariant(billet.statut)}>
+            <Badge variant={statutBilletVariant(billet.statut)}>
               {tBillets(`statut.${billet.statut}`)}
             </Badge>
             <Badge variant={statutPaiementVariant(billet.statutPaiement)}>

--- a/app/[locale]/(app)/billets/page.tsx
+++ b/app/[locale]/(app)/billets/page.tsx
@@ -16,48 +16,11 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { EmptyState } from '@/components/empty-state'
-import type { StatutBillet, StatutPaiement } from '@prisma/client'
+import { formatEuros } from '@/lib/format'
+import { statutBilletVariant, statutPaiementVariant } from '@/lib/ui'
 
 type Props = {
   params: Promise<{ locale: string }>
-}
-
-function formatEuros(euros: number): string {
-  return euros.toFixed(2) + ' EUR'
-}
-
-function statutVariant(statut: StatutBillet): 'outline' | 'default' | 'secondary' | 'destructive' {
-  switch (statut) {
-    case 'EN_ATTENTE':
-      return 'outline'
-    case 'PLANIFIE':
-      return 'default'
-    case 'VOLE':
-      return 'secondary'
-    case 'ANNULE':
-    case 'REMBOURSE':
-    case 'EXPIRE':
-      return 'destructive'
-    default:
-      return 'outline'
-  }
-}
-
-function statutPaiementVariant(
-  statut: StatutPaiement,
-): 'outline' | 'default' | 'secondary' | 'destructive' {
-  switch (statut) {
-    case 'EN_ATTENTE':
-      return 'outline'
-    case 'SOLDE':
-      return 'default'
-    case 'PARTIEL':
-      return 'secondary'
-    case 'REMBOURSE':
-      return 'destructive'
-    default:
-      return 'outline'
-  }
 }
 
 export default async function BilletsPage({ params }: Props) {
@@ -140,7 +103,7 @@ export default async function BilletsPage({ params }: Props) {
                       <TableCell>{billet._count.passagers}</TableCell>
                       <TableCell>{formatEuros(Number(billet.montantTtc))}</TableCell>
                       <TableCell>
-                        <Badge variant={statutVariant(billet.statut)}>
+                        <Badge variant={statutBilletVariant(billet.statut)}>
                           {t(`statut.${billet.statut}`)}
                         </Badge>
                       </TableCell>

--- a/app/[locale]/(app)/rgpd/rgpd-client.tsx
+++ b/app/[locale]/(app)/rgpd/rgpd-client.tsx
@@ -12,6 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import {
   searchPassagers,
   exportPassagerData,
@@ -43,7 +44,6 @@ export function RgpdClient() {
   }
 
   async function handleAnonymise(passagerId: string) {
-    if (!confirm(t('actions.confirmAnonymise'))) return
     await anonymisePassager(passagerId)
     await handleSearch()
   }
@@ -86,9 +86,18 @@ export function RgpdClient() {
                   <Button size="sm" variant="outline" onClick={() => handleExport(r.id)}>
                     {t('actions.export')}
                   </Button>
-                  <Button size="sm" variant="destructive" onClick={() => handleAnonymise(r.id)}>
-                    {t('actions.anonymise')}
-                  </Button>
+                  <ConfirmDialog
+                    title={t('actions.confirmAnonymiseTitle')}
+                    description={t('actions.confirmAnonymise')}
+                    confirmLabel={t('actions.anonymise')}
+                    destructive
+                    onConfirm={() => handleAnonymise(r.id)}
+                    trigger={
+                      <Button size="sm" variant="destructive">
+                        {t('actions.anonymise')}
+                      </Button>
+                    }
+                  />
                 </TableCell>
               </TableRow>
             ))}

--- a/app/[locale]/(app)/settings/tag-manager.tsx
+++ b/app/[locale]/(app)/settings/tag-manager.tsx
@@ -7,6 +7,7 @@ import { X, Plus } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { createTag, deleteTag } from '@/lib/actions/tag'
 
 type TagData = { id: string; nom: string; couleur: string | null }
@@ -34,7 +35,6 @@ export function TagManager({ tags }: { tags: TagData[] }) {
   }
 
   function handleDelete(tagId: string) {
-    if (!confirm(t('deleteConfirm'))) return
     startTransition(async () => {
       const result = await deleteTag(tagId)
       if (result.error) {
@@ -58,13 +58,23 @@ export function TagManager({ tags }: { tags: TagData[] }) {
             style={tag.couleur ? { borderColor: tag.couleur, color: tag.couleur } : undefined}
           >
             {tag.nom}
-            <button
-              onClick={() => handleDelete(tag.id)}
-              className="ml-1 rounded-full p-0.5 hover:bg-muted"
-              disabled={pending}
-            >
-              <X className="h-3 w-3" />
-            </button>
+            <ConfirmDialog
+              title={t('deleteConfirmTitle')}
+              description={t('deleteConfirm')}
+              confirmLabel={t('delete')}
+              destructive
+              onConfirm={() => handleDelete(tag.id)}
+              trigger={
+                <button
+                  type="button"
+                  aria-label={t('delete')}
+                  className="ml-1 rounded-full p-0.5 hover:bg-muted disabled:opacity-50"
+                  disabled={pending}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              }
+            />
           </Badge>
         ))}
       </div>

--- a/app/[locale]/(app)/vols/[id]/page.tsx
+++ b/app/[locale]/(app)/vols/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 import { formatDateFr, formatDateTimeShort } from '@/lib/format'
+import { statutVolVariant } from '@/lib/ui'
 import { VolActions } from './vol-actions'
 import { MeteoAlertBanner } from '@/components/meteo-alert-banner'
 import { WeatherTable } from '@/components/weather-table'
@@ -34,23 +35,6 @@ import type { StatutVol } from '@prisma/client'
 
 type Props = {
   params: Promise<{ locale: string; id: string }>
-}
-
-function statutVariant(statut: StatutVol): 'outline' | 'default' | 'secondary' | 'destructive' {
-  switch (statut) {
-    case 'PLANIFIE':
-      return 'default'
-    case 'CONFIRME':
-      return 'default'
-    case 'TERMINE':
-      return 'secondary'
-    case 'ARCHIVE':
-      return 'outline'
-    case 'ANNULE':
-      return 'destructive'
-    default:
-      return 'outline'
-  }
 }
 
 function statutClassName(statut: StatutVol): string {
@@ -202,7 +186,7 @@ export default async function VolDetailPage({ params }: Props) {
             </div>
             <div className="flex items-center gap-2">
               <Badge
-                variant={statutVariant(vol.statut)}
+                variant={statutVolVariant(vol.statut)}
                 className={cn(statutClassName(vol.statut))}
               >
                 {t(`statut.${vol.statut}`)}

--- a/app/[locale]/(app)/vols/[id]/vol-actions.tsx
+++ b/app/[locale]/(app)/vols/[id]/vol-actions.tsx
@@ -2,8 +2,10 @@
 
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { useState, useTransition } from 'react'
+import { toast } from 'sonner'
 import { Button, buttonVariants } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { cn } from '@/lib/utils'
 import { cancelVol, archivePve } from '@/lib/actions/vol'
 import { confirmerVol } from '@/lib/actions/organisation'
@@ -17,31 +19,46 @@ type Props = {
 
 export function VolActions({ volId, locale, statut, canEdit = true }: Props) {
   const t = useTranslations('vols')
+  const [, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
 
-  async function handleCancel() {
-    const confirmed = window.confirm(t('confirmCancel'))
-    if (!confirmed) return
-    const result = await cancelVol(volId, locale)
-    if (result?.error) {
-      setError(result.error)
-    }
+  function handleCancel() {
+    setError(null)
+    startTransition(async () => {
+      const result = await cancelVol(volId, locale)
+      if (result?.error) {
+        setError(result.error)
+        toast.error(result.error)
+        return
+      }
+      toast.success(t('cancel'))
+    })
   }
 
-  async function handleConfirmer() {
-    const result = await confirmerVol(volId, locale)
-    if (result?.error) {
-      setError(result.error)
-    }
+  function handleConfirmer() {
+    setError(null)
+    startTransition(async () => {
+      const result = await confirmerVol(volId, locale)
+      if (result?.error) {
+        setError(result.error)
+        toast.error(result.error)
+        return
+      }
+      toast.success(t('confirmer'))
+    })
   }
 
-  async function handleArchive() {
-    const confirmed = window.confirm(t('confirmArchive'))
-    if (!confirmed) return
-    const result = await archivePve(volId, locale)
-    if (result?.error) {
-      setError(result.error)
-    }
+  function handleArchive() {
+    setError(null)
+    startTransition(async () => {
+      const result = await archivePve(volId, locale)
+      if (result?.error) {
+        setError(result.error)
+        toast.error(result.error)
+        return
+      }
+      toast.success(t('archivePve'))
+    })
   }
 
   const showFiche = statut === 'CONFIRME' || statut === 'TERMINE'
@@ -72,9 +89,13 @@ export function VolActions({ volId, locale, statut, canEdit = true }: Props) {
         </Button>
       )}
       {canEdit && statut === 'TERMINE' && (
-        <Button size="sm" onClick={handleArchive}>
-          {t('archivePve')}
-        </Button>
+        <ConfirmDialog
+          title={t('confirmArchiveTitle')}
+          description={t('confirmArchive')}
+          confirmLabel={t('archivePve')}
+          onConfirm={handleArchive}
+          trigger={<Button size="sm">{t('archivePve')}</Button>}
+        />
       )}
       {statut === 'ARCHIVE' && (
         <a
@@ -86,9 +107,18 @@ export function VolActions({ volId, locale, statut, canEdit = true }: Props) {
         </a>
       )}
       {canEdit && statut !== 'ARCHIVE' && statut !== 'ANNULE' && (
-        <Button variant="destructive" size="sm" onClick={handleCancel}>
-          {t('cancel')}
-        </Button>
+        <ConfirmDialog
+          title={t('confirmCancelTitle')}
+          description={t('confirmCancel')}
+          confirmLabel={t('cancel')}
+          destructive
+          onConfirm={handleCancel}
+          trigger={
+            <Button variant="destructive" size="sm">
+              {t('cancel')}
+            </Button>
+          }
+        />
       )}
     </div>
   )

--- a/app/[locale]/admin/audit/audit-client.tsx
+++ b/app/[locale]/admin/audit/audit-client.tsx
@@ -14,6 +14,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { fetchAdminAuditLogs } from '@/lib/actions/admin'
+import { formatDateTimeFr } from '@/lib/format'
 
 const ENTITY_TYPES = ['Ballon', 'Pilote', 'Billet', 'Passager', 'Paiement', 'Vol', 'AUTH']
 const ACTIONS = [
@@ -90,10 +91,6 @@ export function AdminAuditClient({
       cancelled = true
     }
   }, [exploitantId, entityType, action, page])
-
-  function formatDate(date: Date) {
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   function formatJson(value: unknown): string {
     if (value === null || value === undefined) return '--'
@@ -202,7 +199,7 @@ export function AdminAuditClient({
             <TableBody>
               {logs.map((log) => (
                 <TableRow key={String(log.id)}>
-                  <TableCell className="text-xs">{formatDate(log.createdAt)}</TableCell>
+                  <TableCell className="text-xs">{formatDateTimeFr(log.createdAt)}</TableCell>
                   <TableCell className="text-xs">
                     {log.exploitantId ? (exploitantMap.get(log.exploitantId) ?? '--') : '--'}
                   </TableCell>

--- a/app/[locale]/admin/sessions/page.tsx
+++ b/app/[locale]/admin/sessions/page.tsx
@@ -9,6 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { formatDateTimeFr } from '@/lib/format'
 import { RevokeSessionButton } from './revoke-button'
 
 export default async function AdminSessionsPage() {
@@ -21,10 +22,6 @@ export default async function AdminSessionsPage() {
     },
     orderBy: { createdAt: 'desc' },
   })
-
-  function formatDate(date: Date): string {
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   function truncateUA(ua: string | null): string {
     if (!ua) return '--'
@@ -66,8 +63,8 @@ export default async function AdminSessionsPage() {
                     <TableCell className="text-xs max-w-48 truncate">
                       {truncateUA(session.userAgent)}
                     </TableCell>
-                    <TableCell className="text-xs">{formatDate(session.createdAt)}</TableCell>
-                    <TableCell className="text-xs">{formatDate(session.expiresAt)}</TableCell>
+                    <TableCell className="text-xs">{formatDateTimeFr(session.createdAt)}</TableCell>
+                    <TableCell className="text-xs">{formatDateTimeFr(session.expiresAt)}</TableCell>
                     <TableCell>
                       <RevokeSessionButton sessionId={session.id} />
                     </TableCell>

--- a/app/[locale]/admin/users/page.tsx
+++ b/app/[locale]/admin/users/page.tsx
@@ -10,6 +10,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
+import { formatDateTimeFr } from '@/lib/format'
 import { UserBanButton } from './user-ban-button'
 
 export default async function AdminUsersPage() {
@@ -31,11 +32,6 @@ export default async function AdminUsersPage() {
     select: { userId: true, createdAt: true },
   })
   const lastLoginMap = new Map(latestSessions.map((s) => [s.userId, s.createdAt]))
-
-  function formatDate(date: Date | null): string {
-    if (!date) return '--'
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   return (
     <div className="space-y-6">
@@ -75,7 +71,9 @@ export default async function AdminUsersPage() {
                     </TableCell>
                     <TableCell>{user.exploitant.name}</TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {formatDate(lastLoginMap.get(user.id) ?? null)}
+                      {lastLoginMap.get(user.id)
+                        ? formatDateTimeFr(lastLoginMap.get(user.id)!)
+                        : '--'}
                     </TableCell>
                     <TableCell>
                       {user.banned ? (

--- a/app/[locale]/admin/users/user-ban-button.tsx
+++ b/app/[locale]/admin/users/user-ban-button.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from 'react'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { toggleUserBan } from '@/lib/actions/admin'
 import { Ban, CircleCheck } from 'lucide-react'
 
@@ -17,15 +18,12 @@ export function UserBanButton({ userId, banned }: Props) {
   const [pending, startTransition] = useTransition()
   const [optimisticBanned, setOptimisticBanned] = useState(banned)
 
-  function handleClick() {
-    const next = !optimisticBanned
-    if (next && !confirm(t('banConfirm'))) return
-
+  function applyToggle(next: boolean) {
     startTransition(async () => {
       setOptimisticBanned(next)
       const result = await toggleUserBan({ userId, banned: next })
       if (result.error) {
-        setOptimisticBanned(!next) // revert
+        setOptimisticBanned(!next)
         toast.error(result.error)
         return
       }
@@ -33,25 +31,34 @@ export function UserBanButton({ userId, banned }: Props) {
     })
   }
 
+  if (optimisticBanned) {
+    return (
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={pending}
+        onClick={() => applyToggle(false)}
+      >
+        <CircleCheck className="h-3.5 w-3.5 mr-1" />
+        {t('unban')}
+      </Button>
+    )
+  }
+
   return (
-    <Button
-      type="button"
-      size="sm"
-      variant={optimisticBanned ? 'outline' : 'ghost'}
-      disabled={pending}
-      onClick={handleClick}
-    >
-      {optimisticBanned ? (
-        <>
-          <CircleCheck className="h-3.5 w-3.5 mr-1" />
-          {t('unban')}
-        </>
-      ) : (
-        <>
+    <ConfirmDialog
+      title={t('banConfirmTitle')}
+      description={t('banConfirm')}
+      confirmLabel={t('ban')}
+      destructive
+      onConfirm={() => applyToggle(true)}
+      trigger={
+        <Button type="button" size="sm" variant="ghost" disabled={pending}>
           <Ban className="h-3.5 w-3.5 mr-1" />
           {t('ban')}
-        </>
-      )}
-    </Button>
+        </Button>
+      }
+    />
   )
 }

--- a/components/auth/two-factor-card.tsx
+++ b/components/auth/two-factor-card.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { PasswordInput } from '@/components/auth/password-input'
 import { authClient } from '@/lib/auth-client'
 import { formLabelClass } from '@/lib/ui'
@@ -76,9 +77,7 @@ export function TwoFactorCard({ enabled }: Props) {
     }
   }
 
-  async function handleDisable(e: React.FormEvent) {
-    e.preventDefault()
-    if (!confirm(t('disableConfirm'))) return
+  async function handleDisable() {
     setLoading(true)
     setError(null)
     try {
@@ -208,7 +207,7 @@ export function TwoFactorCard({ enabled }: Props) {
         )}
 
         {view.kind === 'enabled' && (
-          <form onSubmit={handleDisable} className="space-y-3">
+          <div className="space-y-3">
             <p className="text-sm">{t('enabledHint')}</p>
             <div>
               <Label htmlFor="tfa-password-disable" className={formLabelClass}>
@@ -222,10 +221,19 @@ export function TwoFactorCard({ enabled }: Props) {
                 disabled={loading}
               />
             </div>
-            <Button type="submit" variant="destructive" disabled={loading || !password}>
-              {loading ? t('disabling') : t('disableButton')}
-            </Button>
-          </form>
+            <ConfirmDialog
+              title={t('disableConfirmTitle')}
+              description={t('disableConfirm')}
+              confirmLabel={t('disableButton')}
+              destructive
+              onConfirm={handleDisable}
+              trigger={
+                <Button type="button" variant="destructive" disabled={loading || !password}>
+                  {loading ? t('disabling') : t('disableButton')}
+                </Button>
+              }
+            />
+          </div>
         )}
       </CardContent>
     </Card>

--- a/components/confirm-dialog.tsx
+++ b/components/confirm-dialog.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import * as React from 'react'
+import { useTranslations } from 'next-intl'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/ui/button'
+
+type Props = {
+  trigger: React.ReactNode
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+  onConfirm: () => void | Promise<void>
+}
+
+export function ConfirmDialog({
+  trigger,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  destructive = false,
+  onConfirm,
+}: Props) {
+  const t = useTranslations('common')
+  const [open, setOpen] = React.useState(false)
+  const [pending, setPending] = React.useState(false)
+
+  async function handleConfirm(e: React.MouseEvent) {
+    e.preventDefault()
+    setPending(true)
+    try {
+      await onConfirm()
+      setOpen(false)
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>{cancelLabel ?? t('cancel')}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={pending}
+            className={cn(destructive && buttonVariants({ variant: 'destructive' }))}
+          >
+            {confirmLabel ?? t('confirm')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/expiry-badge.tsx
+++ b/components/expiry-badge.tsx
@@ -1,5 +1,7 @@
+import { getTranslations } from 'next-intl/server'
 import { Badge } from '@/components/ui/badge'
 import { computeAlertSeverity } from '@/lib/regulatory/alerts'
+import { formatDateFr } from '@/lib/format'
 
 interface ExpiryBadgeProps {
   date: Date
@@ -8,29 +10,27 @@ interface ExpiryBadgeProps {
 
 const severityConfig: Record<
   string,
-  { label: string; variant: 'success' | 'warning' | 'critical' | 'destructive' | 'outline' }
+  {
+    labelKey: 'valid' | 'warning' | 'critical' | 'expired'
+    variant: 'success' | 'warning' | 'critical' | 'destructive'
+  }
 > = {
-  OK: { label: 'Valide', variant: 'success' },
-  WARNING: { label: 'Attention', variant: 'warning' },
-  CRITICAL: { label: 'Critique', variant: 'critical' },
-  EXPIRED: { label: 'Expiré', variant: 'destructive' },
+  OK: { labelKey: 'valid', variant: 'success' },
+  WARNING: { labelKey: 'warning', variant: 'warning' },
+  CRITICAL: { labelKey: 'critical', variant: 'critical' },
+  EXPIRED: { labelKey: 'expired', variant: 'destructive' },
 }
 
-export function ExpiryBadge({ date, type }: ExpiryBadgeProps) {
+export async function ExpiryBadge({ date, type }: ExpiryBadgeProps) {
+  const t = await getTranslations('alerts')
   const severity = computeAlertSeverity(date, type)
-  const { label, variant } = severityConfig[severity] ?? {
-    label: severity,
-    variant: 'outline' as const,
-  }
-  const dateStr = date.toLocaleDateString('fr-FR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  })
+  const config = severityConfig[severity]
+  const label = config ? t(config.labelKey) : severity
+  const variant = config?.variant ?? 'outline'
 
   return (
     <Badge variant={variant}>
-      {label} — {dateStr}
+      {label} — {formatDateFr(date)}
     </Badge>
   )
 }

--- a/components/flight-card.tsx
+++ b/components/flight-card.tsx
@@ -160,7 +160,7 @@ export function FlightCard({ flight, locale, showActions = true, userRole }: Pro
           </div>
         </div>
       ) : (
-        <div className="text-xs italic text-sky-400">{t('massUnavailable')}</div>
+        <div className="text-xs italic text-sky-600">{t('massUnavailable')}</div>
       )}
 
       {/* Weather strip — wrapped in Suspense so a descendant can `use()` a
@@ -234,7 +234,7 @@ function WeatherStrip({
           className="text-sky-500"
         />
         <MonoValue value={weather.maxWindKmh} unit="km/h" size={12} />
-        <span className="text-[10px] text-sky-400">({weather.maxWindAltitude})</span>
+        <span className="text-[10px] text-sky-600">({weather.maxWindAltitude})</span>
       </div>
       <div className="flex items-center gap-1 text-sky-700">
         <Thermometer className="h-3.5 w-3.5 text-sky-500" aria-hidden />

--- a/components/linked-accounts.tsx
+++ b/components/linked-accounts.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { Check, Link2, Unlink } from 'lucide-react'
 
 type Props = {
@@ -60,7 +61,6 @@ export function LinkedAccounts({ linkedProviders, hasCredential }: Props) {
   }
 
   async function handleUnlink(provider: 'google') {
-    if (!confirm(t('unlinkConfirm'))) return
     setLoading(provider)
     try {
       const result = await authClient.unlinkAccount({ providerId: provider })
@@ -123,15 +123,25 @@ export function LinkedAccounts({ linkedProviders, hasCredential }: Props) {
               </div>
             </div>
             {googleLinked ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleUnlink('google')}
-                disabled={loading === 'google' || (!hasCredential && linkedProviders.length === 1)}
-              >
-                <Unlink className="h-3.5 w-3.5 mr-1" />
-                {t('unlink')}
-              </Button>
+              <ConfirmDialog
+                title={t('unlinkConfirmTitle')}
+                description={t('unlinkConfirm')}
+                confirmLabel={t('unlink')}
+                destructive
+                onConfirm={() => handleUnlink('google')}
+                trigger={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={
+                      loading === 'google' || (!hasCredential && linkedProviders.length === 1)
+                    }
+                  >
+                    <Unlink className="h-3.5 w-3.5 mr-1" />
+                    {t('unlink')}
+                  </Button>
+                }
+              />
             ) : (
               <Button
                 variant="outline"

--- a/components/meteo-alert-banner.tsx
+++ b/components/meteo-alert-banner.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import { AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { cancelVol } from '@/lib/actions/vol'
 
 type Props = {
@@ -17,7 +18,6 @@ export function MeteoAlertBanner({ volId, locale }: Props) {
   const [pending, startTransition] = useTransition()
 
   function handleCancel() {
-    if (!confirm(t('cancelMeteoConfirm'))) return
     startTransition(async () => {
       const result = await cancelVol(volId, locale, 'Météo')
       if (result?.error) {
@@ -32,9 +32,18 @@ export function MeteoAlertBanner({ volId, locale }: Props) {
       <span className="flex-1">
         {t('meteoAlert')} — {t('meteoAlertAction')}
       </span>
-      <Button size="sm" variant="destructive" onClick={handleCancel} disabled={pending}>
-        {t('cancelMeteo')}
-      </Button>
+      <ConfirmDialog
+        title={t('cancelMeteoTitle')}
+        description={t('cancelMeteoConfirm')}
+        confirmLabel={t('cancelMeteo')}
+        destructive
+        onConfirm={handleCancel}
+        trigger={
+          <Button size="sm" variant="destructive" disabled={pending}>
+            {t('cancelMeteo')}
+          </Button>
+        }
+      />
     </div>
   )
 }

--- a/components/my-sessions-card.tsx
+++ b/components/my-sessions-card.tsx
@@ -7,6 +7,7 @@ import { Loader2, Monitor, Smartphone } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { revokeMySession, type MySession } from '@/lib/actions/session'
 import { formatDateTimeShort } from '@/lib/format'
 
@@ -41,7 +42,6 @@ export function MySessionsCard({ sessions }: Props) {
   const [revoked, setRevoked] = useState<Set<string>>(new Set())
 
   function handleRevoke(sessionId: string) {
-    if (!window.confirm(t('revokeConfirm'))) return
     setRevokingId(sessionId)
     startTransition(async () => {
       const result = await revokeMySession(sessionId)
@@ -88,15 +88,19 @@ export function MySessionsCard({ sessions }: Props) {
                     </p>
                   </div>
                   {!s.isCurrent && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={isRevoking}
-                      onClick={() => handleRevoke(s.id)}
-                    >
-                      {isRevoking && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
-                      {t('revoke')}
-                    </Button>
+                    <ConfirmDialog
+                      title={t('revokeConfirmTitle')}
+                      description={t('revokeConfirm')}
+                      confirmLabel={t('revoke')}
+                      destructive
+                      onConfirm={() => handleRevoke(s.id)}
+                      trigger={
+                        <Button variant="outline" size="sm" disabled={isRevoking}>
+                          {isRevoking && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
+                          {t('revoke')}
+                        </Button>
+                      }
+                    />
                   )}
                 </li>
               )

--- a/components/toggle-actif-button.tsx
+++ b/components/toggle-actif-button.tsx
@@ -4,6 +4,7 @@ import { useTransition } from 'react'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 
 type Props = {
   actif: boolean
@@ -18,11 +19,8 @@ export function ToggleActifButton({ actif, onToggle, id, locale, action }: Props
   const t = useTranslations('common')
   const [pending, startTransition] = useTransition()
 
-  function handleClick() {
+  function applyToggle() {
     const next = !actif
-    const msg = next ? t('activateConfirm') : t('deactivateConfirm')
-    if (!confirm(msg)) return
-
     startTransition(async () => {
       let result: { error?: string }
       if (onToggle) {
@@ -38,14 +36,22 @@ export function ToggleActifButton({ actif, onToggle, id, locale, action }: Props
     })
   }
 
+  const next = !actif
+  const title = next ? t('activateConfirmTitle') : t('deactivateConfirmTitle')
+  const description = next ? t('activateConfirm') : t('deactivateConfirm')
+
   return (
-    <Button
-      variant={actif ? 'outline' : 'default'}
-      size="sm"
-      onClick={handleClick}
-      disabled={pending}
-    >
-      {actif ? t('deactivate') : t('activate')}
-    </Button>
+    <ConfirmDialog
+      title={title}
+      description={description}
+      confirmLabel={next ? t('activate') : t('deactivate')}
+      destructive={!next}
+      onConfirm={applyToggle}
+      trigger={
+        <Button variant={actif ? 'outline' : 'default'} size="sm" disabled={pending}>
+          {actif ? t('deactivate') : t('activate')}
+        </Button>
+      }
+    />
   )
 }

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import * as React from 'react'
+import { AlertDialog as AlertDialogPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/ui/button'
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      data-slot="alert-dialog-action"
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      data-slot="alert-dialog-cancel"
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        xs: "h-7 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
         icon: 'size-9',

--- a/lib/actions/rgpd.ts
+++ b/lib/actions/rgpd.ts
@@ -6,7 +6,8 @@ import { requireRole } from '@/lib/auth/requireRole'
 import { writeAudit } from '@/lib/audit/write'
 import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
-import { safeDecryptInt, safeDecryptString } from '@/lib/crypto'
+import { decrypt, safeDecryptString } from '@/lib/crypto'
+import { logger } from '@/lib/logger'
 
 export type PassagerSearchResult = {
   id: string
@@ -93,7 +94,21 @@ export async function exportPassagerData(passagerId: string): Promise<string> {
       include: { billet: { include: { paiements: true } } },
     })
 
-    const poids = passager.poidsEncrypted ? safeDecryptInt(passager.poidsEncrypted, 0) : null
+    // RGPD Art. 15: a data-subject access request must reflect what we actually
+    // hold. Returning a fallback (e.g. 0) on a corrupt blob would silently
+    // misrepresent the truth, so we surface it as null and log the corruption.
+    let poids: number | null = null
+    if (passager.poidsEncrypted) {
+      try {
+        const parsed = parseInt(decrypt(passager.poidsEncrypted), 10)
+        poids = Number.isNaN(parsed) ? null : parsed
+      } catch (err) {
+        logger.error(
+          { err, passagerId: passager.id },
+          'rgpd: failed to decrypt poidsEncrypted during PII export',
+        )
+      }
+    }
 
     const data = {
       passager: {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -11,8 +11,26 @@ const resendApiKey = process.env.RESEND_API_KEY
 const resend =
   resendApiKey && resendApiKey !== 'resend-key-not-configured' ? new Resend(resendApiKey) : null
 
+// Better Auth signs sessions, magic-link tokens, and TOTP secrets with this key.
+// We require at least 32 bytes of entropy to keep HMAC-SHA256 outputs sound and
+// to deter brute-force on encrypted blobs (TOTP secrets, backup codes).
+function resolveAuthSecret(): string {
+  const secret = process.env.BETTER_AUTH_SECRET ?? process.env.AUTH_SECRET
+  if (!secret || secret.length < 32) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'BETTER_AUTH_SECRET must be set to at least 32 characters in production. Generate one with `openssl rand -base64 32`.',
+      )
+    }
+    console.warn(
+      '[auth] BETTER_AUTH_SECRET is missing or shorter than 32 characters. This is unsafe outside local development.',
+    )
+  }
+  return secret ?? ''
+}
+
 export const auth = betterAuth({
-  secret: process.env.BETTER_AUTH_SECRET ?? process.env.AUTH_SECRET,
+  secret: resolveAuthSecret(),
   baseURL:
     process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000',
   trustedOrigins: ['https://calpax.fr', 'https://www.calpax.fr'],

--- a/lib/db/audit-extension.ts
+++ b/lib/db/audit-extension.ts
@@ -18,6 +18,8 @@ const REDACT_FIELDS = new Set([
   'payeurPrenom',
   'payeurNom',
   'poidsEncrypted',
+  'emailEncrypted',
+  'telephoneEncrypted',
 ])
 
 function redactSensitive(obj: Record<string, unknown>): Record<string, unknown> {

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -36,3 +36,11 @@ export function formatDateTimeShort(date: Date, locale: string): string {
     minute: '2-digit',
   })
 }
+
+export function formatDateTimeFr(date: Date | string): string {
+  return new Date(date).toLocaleString('fr-FR')
+}
+
+export function formatEuros(amount: number): string {
+  return amount.toFixed(2) + ' EUR'
+}

--- a/lib/ui.ts
+++ b/lib/ui.ts
@@ -1,2 +1,53 @@
-export const formLabelClass =
-  'text-xs font-medium uppercase tracking-wider text-muted-foreground'
+import type { StatutBillet, StatutPaiement, StatutVol } from '@prisma/client'
+
+export const formLabelClass = 'text-xs font-medium uppercase tracking-wider text-muted-foreground'
+
+export type BadgeVariant = 'outline' | 'default' | 'secondary' | 'destructive'
+
+export function statutBilletVariant(statut: StatutBillet): BadgeVariant {
+  switch (statut) {
+    case 'EN_ATTENTE':
+      return 'outline'
+    case 'PLANIFIE':
+      return 'default'
+    case 'VOLE':
+      return 'secondary'
+    case 'ANNULE':
+    case 'REMBOURSE':
+    case 'EXPIRE':
+      return 'destructive'
+    default:
+      return 'outline'
+  }
+}
+
+export function statutPaiementVariant(statut: StatutPaiement): BadgeVariant {
+  switch (statut) {
+    case 'EN_ATTENTE':
+      return 'outline'
+    case 'SOLDE':
+      return 'default'
+    case 'PARTIEL':
+      return 'secondary'
+    case 'REMBOURSE':
+      return 'destructive'
+    default:
+      return 'outline'
+  }
+}
+
+export function statutVolVariant(statut: StatutVol): BadgeVariant {
+  switch (statut) {
+    case 'PLANIFIE':
+    case 'CONFIRME':
+      return 'default'
+    case 'TERMINE':
+      return 'secondary'
+    case 'ARCHIVE':
+      return 'outline'
+    case 'ANNULE':
+      return 'destructive'
+    default:
+      return 'outline'
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,13 @@
     "activate": "Activate",
     "deactivate": "Deactivate",
     "activateConfirm": "Reactivate this item?",
-    "deactivateConfirm": "Deactivate this item? It will no longer be available for new flights."
+    "activateConfirmTitle": "Reactivate?",
+    "deactivateConfirm": "Deactivate this item? It will no longer be available for new flights.",
+    "deactivateConfirmTitle": "Deactivate?",
+    "yes": "Yes",
+    "no": "No",
+    "cancel": "Cancel",
+    "confirm": "Confirm"
   },
   "home": {
     "signedInAs": "Signed in as {name} — Operator {exploitant}",
@@ -146,6 +152,7 @@
       "banned": "Disabled",
       "ban": "Disable",
       "unban": "Reactivate",
+      "banConfirmTitle": "Disable this user?",
       "banConfirm": "Disable this user? Their active sessions will be revoked and they will no longer be able to sign in.",
       "banSuccess": "User disabled",
       "unbanSuccess": "User reactivated",
@@ -212,6 +219,8 @@
     "title": "Regulatory alerts",
     "expired": "Expired",
     "critical": "Critical",
+    "valid": "Valid",
+    "warning": "Warning",
     "daysRemaining": "{days, plural, =0 {Expired} one {# day} other {# days}}",
     "summary": "{count, plural, one {# regulatory alert} other {# regulatory alerts}} ({parts})",
     "count": "{count, plural, one {# regulatory alert} other {# regulatory alerts}}",
@@ -478,6 +487,7 @@
     "backToList": "Back to planning",
     "detail": "Flight detail",
     "cancel": "Cancel flight",
+    "confirmCancelTitle": "Cancel this flight?",
     "confirmCancel": "Cancel this flight? Passengers will be unassigned.",
     "organiser": "Organise",
     "confirmer": "Confirm flight",
@@ -575,6 +585,7 @@
     "downloadFiche": "Download flight sheet",
     "downloadPve": "Download PVE",
     "archivePve": "Archive as PVE",
+    "confirmArchiveTitle": "Archive this flight?",
     "confirmArchive": "Generate final PVE and archive this flight?",
     "postVolLink": "Post-flight entry"
   },
@@ -708,6 +719,7 @@
       "view": "View",
       "export": "Export (JSON)",
       "anonymise": "Anonymise",
+      "confirmAnonymiseTitle": "Anonymise this passenger?",
       "confirmAnonymise": "This action is irreversible. Personal data will be deleted. Confirm?"
     },
     "anonymised": "Data anonymised"
@@ -747,6 +759,7 @@
     "windAriaLabelKpi": "Max wind {speed} km/h",
     "meteoAlertAction": "Cancel this flight?",
     "cancelMeteo": "Cancel (weather)",
+    "cancelMeteoTitle": "Cancel this flight due to weather?",
     "cancelMeteoConfirm": "Cancel this flight due to weather? Passengers will be unassigned and contacts notified by email.",
     "window": {
       "title": "Today's flight window",
@@ -796,6 +809,7 @@
     "name": "Tag name",
     "color": "Color",
     "delete": "Delete",
+    "deleteConfirmTitle": "Delete this tag?",
     "deleteConfirm": "Delete this tag? It will be removed from all tickets.",
     "noTags": "No tags",
     "addToBillet": "Add a tag",
@@ -825,6 +839,7 @@
       "description": "Devices currently signed in to your account. You can revoke a session to sign out that device.",
       "currentSession": "Current session",
       "revoke": "Sign out",
+      "revokeConfirmTitle": "Sign out this device?",
       "revokeConfirm": "Sign out this device? The session will be revoked immediately.",
       "revokeSuccess": "Session revoked",
       "empty": "No active sessions."
@@ -839,6 +854,7 @@
       "active": "Active",
       "link": "Link",
       "unlink": "Unlink",
+      "unlinkConfirmTitle": "Unlink this account?",
       "unlinkConfirm": "Are you sure you want to unlink this account? You will not be able to sign in with this method anymore.",
       "unlinkSuccess": "Account unlinked",
       "unlinkError": "Unable to unlink this account",
@@ -869,6 +885,7 @@
       "enabledHint": "2FA is active on your account. To disable, confirm your password.",
       "disableButton": "Disable 2FA",
       "disabling": "Disabling…",
+      "disableConfirmTitle": "Disable two-factor authentication?",
       "disableConfirm": "Disable two-factor authentication? You can re-enable it later.",
       "disableSuccess": "Two-factor authentication disabled",
       "disableError": "Unable to disable 2FA. Check your password."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -15,7 +15,13 @@
     "activate": "Activer",
     "deactivate": "Désactiver",
     "activateConfirm": "Réactiver cet élément ?",
-    "deactivateConfirm": "Désactiver cet élément ? Il ne sera plus sélectionnable pour les nouveaux vols."
+    "activateConfirmTitle": "Réactiver ?",
+    "deactivateConfirm": "Désactiver cet élément ? Il ne sera plus sélectionnable pour les nouveaux vols.",
+    "deactivateConfirmTitle": "Désactiver ?",
+    "yes": "Oui",
+    "no": "Non",
+    "cancel": "Annuler",
+    "confirm": "Confirmer"
   },
   "home": {
     "signedInAs": "Connecté en tant que {name} — Exploitant {exploitant}",
@@ -146,6 +152,7 @@
       "banned": "Désactivé",
       "ban": "Désactiver",
       "unban": "Réactiver",
+      "banConfirmTitle": "Désactiver cet utilisateur ?",
       "banConfirm": "Désactiver cet utilisateur ? Ses sessions actives seront révoquées et il ne pourra plus se connecter.",
       "banSuccess": "Utilisateur désactivé",
       "unbanSuccess": "Utilisateur réactivé",
@@ -212,6 +219,8 @@
     "title": "Alertes réglementaires",
     "expired": "Expiré",
     "critical": "Critique",
+    "valid": "Valide",
+    "warning": "Attention",
     "daysRemaining": "{days, plural, =0 {Expiré} one {# jour} other {# jours}}",
     "summary": "{count, plural, one {# alerte réglementaire} other {# alertes réglementaires}} ({parts})",
     "count": "{count, plural, one {# alerte réglementaire} other {# alertes réglementaires}}",
@@ -478,6 +487,7 @@
     "backToList": "Retour au planning",
     "detail": "Détail du vol",
     "cancel": "Annuler le vol",
+    "confirmCancelTitle": "Annuler ce vol ?",
     "confirmCancel": "Annuler ce vol ? Les passagers seront désaffectés.",
     "organiser": "Organiser",
     "confirmer": "Confirmer le vol",
@@ -575,6 +585,7 @@
     "downloadFiche": "Télécharger PVE",
     "downloadPve": "Télécharger PVE",
     "archivePve": "Archiver comme PVE",
+    "confirmArchiveTitle": "Archiver ce vol ?",
     "confirmArchive": "Générer le PVE final et archiver ce vol ?",
     "postVolLink": "Saisie post-vol"
   },
@@ -708,6 +719,7 @@
       "view": "Consulter",
       "export": "Exporter (JSON)",
       "anonymise": "Anonymiser",
+      "confirmAnonymiseTitle": "Anonymiser ce passager ?",
       "confirmAnonymise": "Cette action est irréversible. Les données personnelles seront supprimées. Confirmer ?"
     },
     "anonymised": "Données anonymisées"
@@ -735,6 +747,7 @@
     "windAriaLabelKpi": "Vent maximum {speed} km/h",
     "meteoAlertAction": "Annuler ce vol ?",
     "cancelMeteo": "Annuler (météo)",
+    "cancelMeteoTitle": "Annuler ce vol pour cause météo ?",
     "cancelMeteoConfirm": "Annuler ce vol pour raison météo ? Les passagers seront désaffectés et les contacts notifiés par email.",
     "kicker": "Cockpit du jour",
     "kpi": {
@@ -796,6 +809,7 @@
     "name": "Nom du tag",
     "color": "Couleur",
     "delete": "Supprimer",
+    "deleteConfirmTitle": "Supprimer ce tag ?",
     "deleteConfirm": "Supprimer ce tag ? Il sera retiré de tous les billets.",
     "noTags": "Aucun tag",
     "addToBillet": "Ajouter un tag",
@@ -825,6 +839,7 @@
       "description": "Les appareils actuellement connectés à votre compte. Vous pouvez révoquer une session pour déconnecter l'appareil.",
       "currentSession": "Session actuelle",
       "revoke": "Déconnecter",
+      "revokeConfirmTitle": "Déconnecter cet appareil ?",
       "revokeConfirm": "Déconnecter cet appareil ? La session sera immédiatement révoquée.",
       "revokeSuccess": "Session révoquée",
       "empty": "Aucune session active."
@@ -839,6 +854,7 @@
       "active": "Active",
       "link": "Lier",
       "unlink": "Delier",
+      "unlinkConfirmTitle": "Delier ce compte ?",
       "unlinkConfirm": "Etes-vous sur de vouloir delier ce compte ? Vous ne pourrez plus vous connecter avec cette methode.",
       "unlinkSuccess": "Compte delie",
       "unlinkError": "Impossible de delier ce compte",
@@ -869,6 +885,7 @@
       "enabledHint": "La 2FA est active sur votre compte. Pour la désactiver, confirmez votre mot de passe.",
       "disableButton": "Désactiver la 2FA",
       "disabling": "Désactivation…",
+      "disableConfirmTitle": "Désactiver la double authentification ?",
       "disableConfirm": "Désactiver la double authentification ? Vous pourrez la réactiver plus tard.",
       "disableSuccess": "Double authentification désactivée",
       "disableError": "Impossible de désactiver la 2FA. Vérifiez votre mot de passe."


### PR DESCRIPTION
## Summary

Cross-cutting cleanup driven by a parallel **simplify / security-GDPR / UX** audit of the codebase. Three independent agents reviewed the repo; this PR ships the safe, high-leverage subset of their findings.

### Simplification (DRY)
- **`lib/format.ts`** — add `formatDateTimeFr` and `formatEuros`.
- **`lib/ui.ts`** — add `statutBilletVariant`, `statutPaiementVariant`, `statutVolVariant` (each was duplicated 2–3 times).
- Remove **6 inline copies** of those helpers across `billets/`, `vols/`, `ballons/journal`, and the admin tables.

### UX & accessibility
- **`components/ui/alert-dialog.tsx`** — new shadcn-style Radix `AlertDialog` primitive.
- **`components/confirm-dialog.tsx`** — small wrapper that handles open state + i18n labels.
- Replace **9 `window.confirm()` sites** (vol-actions, tag-manager, user-ban, rgpd-client, meteo-alert-banner, toggle-actif-button, linked-accounts, my-sessions-card, two-factor-card). Adds focus trap, keyboard nav, mobile-friendly modal, success/error toasts on previously-silent destructive actions.
- **`expiry-badge.tsx`** — convert to async server component pulling Valide / Attention / Critique / Expiré from `messages/{fr,en}.json` instead of hardcoded French.
- **`button.tsx`** — bump `xs` touch target 24 → 28 px.
- **`flight-card.tsx`** — lift `text-sky-400` (poor contrast on white) to `text-sky-600`.

### Security & GDPR
- **`lib/auth.ts`** — validate `BETTER_AUTH_SECRET` at startup. Throws in production if missing or shorter than 32 chars (HMAC + TOTP encryption depend on it); warns in dev. _(Was: silent `??` fallback.)_
- **`lib/db/audit-extension.ts`** — add `emailEncrypted` and `telephoneEncrypted` to `REDACT_FIELDS`. Defense in depth — keeps base64 ciphertext blobs out of audit rows even though the underlying values are encrypted at rest.
- **`lib/actions/rgpd.ts`** (RGPD Art. 15) — stop falling back to `0` on a corrupt `poidsEncrypted` blob during PII export. Return `null` and log the decryption failure so the access response stays truthful.

### Deliberately deferred (own PRs)
- **Encrypt Billet payer PII** (`payeurEmail/Telephone/Adresse/Nom`) — needs a dedicated migration with backfill, parallels what #4 / #68 did for Passager.
- **Per-email rate-limit** on magic-link + password-reset endpoints.
- **Per-field inline form validation** across the app.
- **Mobile horizontal-scroll affordance** on `PassagerTableEditor` / `WeatherTable`.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — only pre-existing warnings
- [x] `pnpm test` — 143/143 pass
- [ ] Manually exercise each new ConfirmDialog (cancel vol, archive vol, delete tag, ban/unban user, anonymise passager, weather-cancel banner, toggle actif, unlink Google, revoke session, disable 2FA)
- [ ] Verify expiry badge labels render in EN locale
- [ ] Verify `BETTER_AUTH_SECRET=<28-char>` warns in dev and would throw in prod
- [ ] Sanity-check audit log rows for a Passager update — `emailEncrypted` / `telephoneEncrypted` should now show `[REDACTED]`

https://claude.ai/code/session_019EMo39KYbUfwKroFy2QqqX

---
_Generated by [Claude Code](https://claude.ai/code/session_019EMo39KYbUfwKroFy2QqqX)_