### PR TITLE
review: dedupe date/decrypt helpers + fix i18n &amp; a11y gaps

### DIFF
--- a/app/[locale]/(app)/audit/audit-client.tsx
+++ b/app/[locale]/(app)/audit/audit-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import {
   Table,
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
 import { fetchAuditLogs } from '@/lib/actions/audit'
+import { formatDateTimeShort } from '@/lib/format'
 
 const ENTITY_TYPES = ['Ballon', 'Pilote', 'Billet', 'Passager', 'Paiement', 'Vol', 'AUTH']
 const ACTIONS = [
@@ -40,6 +41,7 @@ type AuditLog = {
 
 export function AuditClient() {
   const t = useTranslations('audit')
+  const locale = useLocale()
   const [entityType, setEntityType] = useState('')
   const [action, setAction] = useState('')
   const [page, setPage] = useState(1)
@@ -62,10 +64,6 @@ export function AuditClient() {
     void load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entityType, action, page])
-
-  function formatDate(date: Date) {
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   function formatJson(value: unknown): string {
     if (value === null || value === undefined) return '—'
@@ -113,9 +111,7 @@ export function AuditClient() {
             ))}
           </select>
         </div>
-        <span className="text-sm text-muted-foreground">
-          {total} {total === 1 ? 'resultat' : 'resultats'}
-        </span>
+        <span className="text-sm text-muted-foreground">{t('results', { count: total })}</span>
       </div>
 
       {/* Table */}
@@ -136,7 +132,9 @@ export function AuditClient() {
           <TableBody>
             {logs.map((log) => (
               <TableRow key={String(log.id)}>
-                <TableCell className="text-xs">{formatDate(log.createdAt)}</TableCell>
+                <TableCell className="text-xs">
+                  {formatDateTimeShort(log.createdAt, locale)}
+                </TableCell>
                 <TableCell>
                   <Badge variant="outline">{log.entityType}</Badge>{' '}
                   <span className="text-xs text-muted-foreground">{log.entityId.slice(0, 8)}</span>
@@ -166,7 +164,7 @@ export function AuditClient() {
             disabled={page <= 1}
             onClick={() => setPage(page - 1)}
           >
-            Precedent
+            {t('prev')}
           </Button>
           <span className="text-sm py-2">
             {page} / {pageCount}
@@ -177,7 +175,7 @@ export function AuditClient() {
             disabled={page >= pageCount}
             onClick={() => setPage(page + 1)}
           >
-            Suivant
+            {t('next')}
           </Button>
         </div>
       )}

--- a/app/[locale]/(app)/billets/[id]/edit/page.tsx
+++ b/app/[locale]/(app)/billets/[id]/edit/page.tsx
@@ -2,7 +2,7 @@ import { getTranslations } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { db } from '@/lib/db'
-import { decrypt, safeDecryptString } from '@/lib/crypto'
+import { safeDecryptIntOrNull, safeDecryptString } from '@/lib/crypto'
 import { BilletForm } from './billet-form'
 import type { PassagerRow } from '@/components/passager-table-editor'
 
@@ -23,23 +23,18 @@ export default async function BilletEditPage({ params }: Props) {
       billet = await db.billet.findUnique({ where: { id }, include: { passagers: true } })
       if (!billet) notFound()
 
-      passagers = billet.passagers.map((p) => ({
-        prenom: p.prenom,
-        nom: p.nom,
-        email: safeDecryptString(p.emailEncrypted) ?? '',
-        telephone: safeDecryptString(p.telephoneEncrypted) ?? '',
-        age: p.age != null ? String(p.age) : '',
-        poids: p.poidsEncrypted
-          ? (() => {
-              try {
-                return String(parseInt(decrypt(p.poidsEncrypted!), 10))
-              } catch {
-                return ''
-              }
-            })()
-          : '',
-        pmr: p.pmr,
-      }))
+      passagers = billet.passagers.map((p) => {
+        const poids = safeDecryptIntOrNull(p.poidsEncrypted)
+        return {
+          prenom: p.prenom,
+          nom: p.nom,
+          email: safeDecryptString(p.emailEncrypted) ?? '',
+          telephone: safeDecryptString(p.telephoneEncrypted) ?? '',
+          age: p.age != null ? String(p.age) : '',
+          poids: poids != null ? String(poids) : '',
+          pmr: p.pmr,
+        }
+      })
     }
 
     return (

--- a/app/[locale]/(app)/pilotes/[id]/edit/page.tsx
+++ b/app/[locale]/(app)/pilotes/[id]/edit/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { db } from '@/lib/db'
-import { decrypt } from '@/lib/crypto'
+import { safeDecryptIntOrNull } from '@/lib/crypto'
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { PiloteEditForm } from './pilote-edit-form'
@@ -20,14 +20,7 @@ export default async function PiloteEditPage({ params }: Props) {
     const pilote = await db.pilote.findUnique({ where: { id } })
     if (!pilote) notFound()
 
-    let poids: number | null = null
-    if (pilote.poidsEncrypted) {
-      try {
-        poids = Number(decrypt(pilote.poidsEncrypted))
-      } catch {
-        poids = null
-      }
-    }
+    const poids = safeDecryptIntOrNull(pilote.poidsEncrypted)
 
     const dateExpirationStr = pilote.dateExpirationLicence
       ? pilote.dateExpirationLicence.toISOString().substring(0, 10)

--- a/app/[locale]/(app)/pilotes/[id]/page.tsx
+++ b/app/[locale]/(app)/pilotes/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { db } from '@/lib/db'
-import { decrypt } from '@/lib/crypto'
+import { safeDecryptIntOrNull } from '@/lib/crypto'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -22,15 +22,7 @@ export default async function PiloteDetailPage({ params }: Props) {
     const pilote = await db.pilote.findUnique({ where: { id } })
     if (!pilote) notFound()
 
-    let poids: number | null = null
-    if (pilote.poidsEncrypted) {
-      try {
-        poids = Number(decrypt(pilote.poidsEncrypted))
-      } catch {
-        // Encrypted with a different key (e.g., seed ran with local key, prod has different key)
-        poids = null
-      }
-    }
+    const poids = safeDecryptIntOrNull(pilote.poidsEncrypted)
 
     return (
       <div className="space-y-6">

--- a/app/[locale]/admin/audit/audit-client.tsx
+++ b/app/[locale]/admin/audit/audit-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo, useId } from 'react'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import {
   Table,
@@ -14,6 +14,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { fetchAdminAuditLogs } from '@/lib/actions/admin'
+import { formatDateTimeShort } from '@/lib/format'
 
 const ENTITY_TYPES = ['Ballon', 'Pilote', 'Billet', 'Passager', 'Paiement', 'Vol', 'AUTH']
 const ACTIONS = [
@@ -61,6 +62,7 @@ export function AdminAuditClient({
 }) {
   const t = useTranslations('audit')
   const ta = useTranslations('admin.audit')
+  const locale = useLocale()
   const [exploitantId, setExploitantId] = useState('')
   const [entityType, setEntityType] = useState('')
   const [action, setAction] = useState('')
@@ -90,10 +92,6 @@ export function AdminAuditClient({
       cancelled = true
     }
   }, [exploitantId, entityType, action, page])
-
-  function formatDate(date: Date) {
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   function formatJson(value: unknown): string {
     if (value === null || value === undefined) return '--'
@@ -202,7 +200,9 @@ export function AdminAuditClient({
             <TableBody>
               {logs.map((log) => (
                 <TableRow key={String(log.id)}>
-                  <TableCell className="text-xs">{formatDate(log.createdAt)}</TableCell>
+                  <TableCell className="text-xs">
+                    {formatDateTimeShort(log.createdAt, locale)}
+                  </TableCell>
                   <TableCell className="text-xs">
                     {log.exploitantId ? (exploitantMap.get(log.exploitantId) ?? '--') : '--'}
                   </TableCell>

--- a/app/[locale]/admin/sessions/page.tsx
+++ b/app/[locale]/admin/sessions/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server'
 import { basePrisma } from '@/lib/db/base'
+import { formatDateTimeFr } from '@/lib/format'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Table,
@@ -21,10 +22,6 @@ export default async function AdminSessionsPage() {
     },
     orderBy: { createdAt: 'desc' },
   })
-
-  function formatDate(date: Date): string {
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   function truncateUA(ua: string | null): string {
     if (!ua) return '--'
@@ -66,8 +63,8 @@ export default async function AdminSessionsPage() {
                     <TableCell className="text-xs max-w-48 truncate">
                       {truncateUA(session.userAgent)}
                     </TableCell>
-                    <TableCell className="text-xs">{formatDate(session.createdAt)}</TableCell>
-                    <TableCell className="text-xs">{formatDate(session.expiresAt)}</TableCell>
+                    <TableCell className="text-xs">{formatDateTimeFr(session.createdAt)}</TableCell>
+                    <TableCell className="text-xs">{formatDateTimeFr(session.expiresAt)}</TableCell>
                     <TableCell>
                       <RevokeSessionButton sessionId={session.id} />
                     </TableCell>

--- a/app/[locale]/admin/users/page.tsx
+++ b/app/[locale]/admin/users/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server'
 import { basePrisma } from '@/lib/db/base'
+import { formatDateTimeFr } from '@/lib/format'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Table,
@@ -34,7 +35,7 @@ export default async function AdminUsersPage() {
 
   function formatDate(date: Date | null): string {
     if (!date) return '--'
-    return new Date(date).toLocaleString('fr-FR')
+    return formatDateTimeFr(date)
   }
 
   return (

--- a/components/cockpit/fleet-row.tsx
+++ b/components/cockpit/fleet-row.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { Chip } from '@/components/cockpit/chip'
 import { MonoValue } from '@/components/cockpit/mono-value'
+import { localeTag } from '@/lib/format'
 
 export type FleetBallon = {
   id: string
@@ -28,7 +29,7 @@ const CAMO_TONE: Record<FleetBallon['camoStatus'], Parameters<typeof Chip>[0]['t
 
 function formatDateShort(dateStr: string, locale: string): string {
   const d = new Date(dateStr + 'T12:00:00Z')
-  return d.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-US', {
+  return d.toLocaleDateString(localeTag(locale), {
     day: '2-digit',
     month: 'short',
   })

--- a/components/cockpit/upcoming-flights-table.tsx
+++ b/components/cockpit/upcoming-flights-table.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { Chip } from '@/components/cockpit/chip'
 import { MonoValue } from '@/components/cockpit/mono-value'
+import { localeTag } from '@/lib/format'
 
 export type UpcomingFlight = {
   id: string
@@ -27,7 +28,7 @@ const STATUT_TONE: Record<string, Parameters<typeof Chip>[0]['tone']> = {
 
 function formatDate(dateStr: string, locale: string): string {
   const d = new Date(dateStr + 'T12:00:00Z')
-  return d.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-US', {
+  return d.toLocaleDateString(localeTag(locale), {
     weekday: 'short',
     day: '2-digit',
     month: 'short',

--- a/components/logo-upload.tsx
+++ b/components/logo-upload.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useTransition } from 'react'
 import { useTranslations } from 'next-intl'
+import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { uploadLogo } from '@/lib/actions/exploitant'
@@ -55,7 +56,8 @@ export function LogoUpload({ currentLogoUrl }: LogoUploadProps) {
           />
         </div>
         <Button type="submit" disabled={isPending} size="sm">
-          {isPending ? '...' : t('logoUploadButton')}
+          {isPending && <Loader2 className="mr-1 h-3 w-3 animate-spin" aria-hidden />}
+          {t('logoUploadButton')}
         </Button>
       </form>
       {error && <p className="text-sm text-destructive">{error}</p>}

--- a/components/my-sessions-card.tsx
+++ b/components/my-sessions-card.tsx
@@ -14,15 +14,18 @@ type Props = {
   sessions: MySession[]
 }
 
-function deviceLabel(ua: string | null): { label: string; icon: typeof Monitor } {
-  if (!ua) return { label: 'Inconnu', icon: Monitor }
+function deviceLabel(
+  ua: string | null,
+  unknownLabel: string,
+): { label: string; icon: typeof Monitor } {
+  if (!ua) return { label: unknownLabel, icon: Monitor }
   const isMobile = /Mobi|Android|iPhone|iPad/i.test(ua)
   const browser =
     (ua.match(/Chrome\/[\d.]+/)?.[0] && 'Chrome') ||
     (ua.match(/Firefox\/[\d.]+/)?.[0] && 'Firefox') ||
     (ua.match(/Safari\/[\d.]+/)?.[0] && 'Safari') ||
     (ua.match(/Edg\/[\d.]+/)?.[0] && 'Edge') ||
-    'Navigateur'
+    unknownLabel
   const os =
     (ua.includes('Windows') && 'Windows') ||
     (ua.includes('Macintosh') && 'macOS') ||
@@ -35,6 +38,7 @@ function deviceLabel(ua: string | null): { label: string; icon: typeof Monitor }
 
 export function MySessionsCard({ sessions }: Props) {
   const t = useTranslations('profil.sessions')
+  const tc = useTranslations('common')
   const locale = useLocale()
   const [pending, startTransition] = useTransition()
   const [revokingId, setRevokingId] = useState<string | null>(null)
@@ -69,7 +73,7 @@ export function MySessionsCard({ sessions }: Props) {
         ) : (
           <ul className="divide-y divide-border">
             {visible.map((s) => {
-              const { label, icon: Icon } = deviceLabel(s.userAgent)
+              const { label, icon: Icon } = deviceLabel(s.userAgent, tc('unknownDevice'))
               const isRevoking = pending && revokingId === s.id
               return (
                 <li key={s.id} className="flex items-center gap-3 py-3">

--- a/components/paiement-form.tsx
+++ b/components/paiement-form.tsx
@@ -22,6 +22,7 @@ type Props = { billetId: string; locale: string }
 
 export function PaiementForm({ billetId, locale }: Props) {
   const t = useTranslations('paiements')
+  const tc = useTranslations('common')
   const [open, setOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [modePaiement, setModePaiement] = useState<string>('')
@@ -89,7 +90,7 @@ export function PaiementForm({ billetId, locale }: Props) {
           {t('add')}
         </Button>
         <Button type="button" variant="ghost" size="sm" onClick={() => setOpen(false)}>
-          Annuler
+          {tc('cancel')}
         </Button>
       </div>
     </form>

--- a/components/passager-table-editor.tsx
+++ b/components/passager-table-editor.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
+import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -111,12 +112,17 @@ export function PassagerTableEditor({ passagers, onChange }: Props) {
               <TableCell>
                 <Input
                   type="email"
+                  inputMode="email"
+                  autoComplete="email"
                   value={row.email}
                   onChange={(e) => updateRow(i, 'email', e.target.value)}
                 />
               </TableCell>
               <TableCell>
                 <Input
+                  type="tel"
+                  inputMode="tel"
+                  autoComplete="tel"
                   value={row.telephone}
                   onChange={(e) => updateRow(i, 'telephone', e.target.value)}
                 />
@@ -130,7 +136,7 @@ export function PassagerTableEditor({ passagers, onChange }: Props) {
                   aria-label={t('removeRow')}
                   title={t('removeRow')}
                 >
-                  X
+                  <Trash2 className="h-4 w-4" aria-hidden />
                 </Button>
               </TableCell>
             </TableRow>

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -46,6 +46,16 @@ export function safeDecryptInt(encrypted: string | null | undefined, fallback: n
   }
 }
 
+export function safeDecryptIntOrNull(encrypted: string | null | undefined): number | null {
+  if (!encrypted) return null
+  try {
+    const parsed = parseInt(decrypt(encrypted), 10)
+    return isNaN(parsed) ? null : parsed
+  } catch {
+    return null
+  }
+}
+
 export function safeDecryptString(
   encrypted: string | null | undefined,
   fallback: string | null = null,

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -6,8 +6,18 @@ export function formatDateFr(date: Date): string {
   })
 }
 
-function localeTag(locale: string): 'fr-FR' | 'en-US' {
+export function localeTag(locale: string): 'fr-FR' | 'en-US' {
   return locale === 'fr' ? 'fr-FR' : 'en-US'
+}
+
+export function formatDateTimeFr(date: Date): string {
+  return date.toLocaleString('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 export function formatDateLong(date: Date, locale: string): string {

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,6 +12,8 @@
     "retry": "Try again",
     "backHome": "Back to home",
     "dismiss": "Dismiss",
+    "cancel": "Cancel",
+    "unknownDevice": "Unknown device",
     "activate": "Activate",
     "deactivate": "Deactivate",
     "activateConfirm": "Reactivate this item?",
@@ -628,6 +630,9 @@
   "audit": {
     "title": "Change log",
     "noEntries": "No changes recorded",
+    "prev": "Previous",
+    "next": "Next",
+    "results": "{count, plural, =0 {No results} one {# result} other {# results}}",
     "filters": {
       "entityType": "Entity type",
       "entityId": "Entity ID",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -12,6 +12,8 @@
     "retry": "Réessayer",
     "backHome": "Retour à l'accueil",
     "dismiss": "Fermer",
+    "cancel": "Annuler",
+    "unknownDevice": "Appareil inconnu",
     "activate": "Activer",
     "deactivate": "Désactiver",
     "activateConfirm": "Réactiver cet élément ?",
@@ -628,6 +630,9 @@
   "audit": {
     "title": "Journal des modifications",
     "noEntries": "Aucune modification enregistrée",
+    "prev": "Précédent",
+    "next": "Suivant",
+    "results": "{count, plural, =0 {Aucun résultat} one {# résultat} other {# résultats}}",
     "filters": {
       "entityType": "Type d'entité",
       "entityId": "ID entité",

--- a/tests/unit/crypto.spec.ts
+++ b/tests/unit/crypto.spec.ts
@@ -57,4 +57,31 @@ describe('lib/crypto', () => {
     const { encrypt } = await import('@/lib/crypto')
     expect(() => encrypt('x')).toThrow(/32 bytes/)
   })
+
+  describe('safeDecryptIntOrNull', () => {
+    it('returns null for nullish input', async () => {
+      const { safeDecryptIntOrNull } = await import('@/lib/crypto')
+      expect(safeDecryptIntOrNull(null)).toBeNull()
+      expect(safeDecryptIntOrNull(undefined)).toBeNull()
+      expect(safeDecryptIntOrNull('')).toBeNull()
+    })
+
+    it('decrypts a valid integer', async () => {
+      const { encrypt, safeDecryptIntOrNull } = await import('@/lib/crypto')
+      expect(safeDecryptIntOrNull(encrypt('85'))).toBe(85)
+    })
+
+    it('returns null on decrypt failure (tampered ciphertext)', async () => {
+      const { encrypt, safeDecryptIntOrNull } = await import('@/lib/crypto')
+      const ct = encrypt('85')
+      const buf = Buffer.from(ct, 'base64')
+      buf[buf.length - 1]! ^= 0xff
+      expect(safeDecryptIntOrNull(buf.toString('base64'))).toBeNull()
+    })
+
+    it('returns null when decrypted value is not a number', async () => {
+      const { encrypt, safeDecryptIntOrNull } = await import('@/lib/crypto')
+      expect(safeDecryptIntOrNull(encrypt('not-a-number'))).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Sweep across the codebase covering simplification, code quality, security/GDPR, and UX. Most findings turned out to be false positives once the existing patterns were verified — I've kept the changes focused on the wins that are unambiguous and low risk.

### What's in scope

**Simplification (reuse existing helpers)**
- `lib/format.ts` exports `localeTag` and adds `formatDateTimeFr` (French-locked, mirrors the existing `formatDateFr` pattern). Replaces inline `toLocaleString('fr-FR')` in 4 admin/audit pages.
- `lib/crypto.ts` adds `safeDecryptIntOrNull` (returns `number | null`). Collapses 3 sites of `decrypt + parseInt + try/catch` (pilote detail/edit, billet edit) — previously 7-9 lines each, now one call.
- Cockpit `fleet-row.tsx` and `upcoming-flights-table.tsx` now reuse `localeTag()` instead of reinventing the `'fr'`→`'fr-FR'` map inline.

**UX / i18n**
- `paiement-form`: hardcoded "Annuler" → `common.cancel`
- `my-sessions-card`: hardcoded "Inconnu"/"Navigateur" → `common.unknownDevice`
- `(app)/audit/audit-client`: hardcoded "Precedent"/"Suivant"/"resultat(s)" → `audit.prev` / `audit.next` / `audit.results` (with ICU plural)
- `logo-upload`: bare `'...'` pending text replaced with a `Loader2` spinner so the action label stays available to screen readers
- `passager-table-editor`: phone field now has `type="tel"` + `inputMode="tel"` + `autoComplete="tel"`; email field gets matching attributes; the bare "X" remove button is now the lucide `Trash2` icon

**Tests**
- New cases for `safeDecryptIntOrNull` (nullish, valid int, tampered ciphertext, non-numeric payload). All 147 unit tests pass.

### What I deliberately skipped

Findings that turned out to be false positives once verified, kept here for the record:
- **REDACT_FIELDS missing payeur PII** — already covered: `payeurEmail/Telephone/Adresse/Nom/Prenom` are all in the set at `lib/db/audit-extension.ts:12-21`.
- **`anonymisePassager` should also wipe billet payer fields** — billet payer ≠ passenger (separate data subject; payer can buy for someone else). Cascading would over-delete; per-subject erasure is the correct GDPR scope.
- **Cron rate-limits too lax** — already conservative: `rgpd-retention` and `digest` use a 6-day cooldown, `rappels` 20h, `meteo-alert` 15min.
- **`basePrisma` in admin pages** — that's by design: admin pages are cross-tenant (super-admin) and `lib/db/base.ts` is whitelisted for `app/**/admin/**` in the ESLint config.
- **Tenant bypass via `findUniqueOrThrow`** — the tenant extension auto-injects `exploitantId`; flagged finding was speculative.

### Validation

- `pnpm typecheck` clean
- `pnpm lint` no new warnings
- `pnpm test` 147/147 passing

## Test plan

- [ ] Open `/<locale>/audit` — pagination buttons render localized "Précédent / Suivant" (fr) and "Previous / Next" (en); result counter pluralizes correctly.
- [ ] Open `/<locale>/admin/sessions` and `/admin/users` — date column unchanged visually (still fr-FR datetime), no regressions.
- [ ] Edit a billet with passengers that have encrypted weight — the weight pre-fills correctly in the table; edit a passenger with corrupted weight ciphertext, the field stays empty (no crash).
- [ ] Open a pilote detail page — weight displays when present, hidden when null/undecryptable.
- [ ] Add a new passenger row on mobile — phone field opens the numeric keypad; autofill suggests saved phone numbers.
- [ ] Trigger the logo upload — the button shows a spinning loader instead of bare `...` while pending.
- [ ] Add a payment from the billet detail page — the "Annuler" button is now translated (English locale shows "Cancel").

https://claude.ai/code/session_01RjQ8v7CNicqJMhKUdtDvvS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjQ8v7CNicqJMhKUdtDvvS)_