### PR TITLE
review: dedupe formatters + i18n gaps + tighter billet validation

### DIFF
--- a/app/[locale]/(app)/billets/[id]/page.tsx
+++ b/app/[locale]/(app)/billets/[id]/page.tsx
@@ -18,15 +18,11 @@ import {
 } from '@/components/ui/table'
 import { PaiementForm } from '@/components/paiement-form'
 import { cn } from '@/lib/utils'
-import { formatDateFr } from '@/lib/format'
+import { formatDateFr, formatEuros } from '@/lib/format'
 import type { StatutBillet, StatutPaiement } from '@prisma/client'
 
 type Props = {
   params: Promise<{ locale: string; id: string }>
-}
-
-function formatEuros(euros: number): string {
-  return euros.toFixed(2) + ' EUR'
 }
 
 function formatDate(date: Date | null | undefined): string {
@@ -137,7 +133,7 @@ export default async function BilletDetailPage({ params }: Props) {
         {/* Payeur card */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Payeur</CardTitle>
+            <CardTitle className="text-base">{tBillets('sections.payeur')}</CardTitle>
           </CardHeader>
           <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             <div>
@@ -183,7 +179,7 @@ export default async function BilletDetailPage({ params }: Props) {
         {/* Planification card */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Planification</CardTitle>
+            <CardTitle className="text-base">{tBillets('sections.planification')}</CardTitle>
           </CardHeader>
           <CardContent className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2">
             <div>
@@ -310,7 +306,9 @@ export default async function BilletDetailPage({ params }: Props) {
         {/* Passagers card */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Passagers ({billet.passagers.length})</CardTitle>
+            <CardTitle className="text-base">
+              {tBillets('sections.passagers')} ({billet.passagers.length})
+            </CardTitle>
           </CardHeader>
           <CardContent>
             {billet.passagers.length === 0 ? (
@@ -345,7 +343,7 @@ export default async function BilletDetailPage({ params }: Props) {
                         <TableCell>{p.nom}</TableCell>
                         <TableCell>{p.age ?? '—'}</TableCell>
                         <TableCell>{poids !== null ? `${poids} kg` : '—'}</TableCell>
-                        <TableCell>{p.pmr ? 'Oui' : 'Non'}</TableCell>
+                        <TableCell>{p.pmr ? tPassagers('pmrYes') : tPassagers('pmrNo')}</TableCell>
                       </TableRow>
                     )
                   })}

--- a/app/[locale]/(app)/billets/page.tsx
+++ b/app/[locale]/(app)/billets/page.tsx
@@ -16,14 +16,11 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { EmptyState } from '@/components/empty-state'
+import { formatEuros } from '@/lib/format'
 import type { StatutBillet, StatutPaiement } from '@prisma/client'
 
 type Props = {
   params: Promise<{ locale: string }>
-}
-
-function formatEuros(euros: number): string {
-  return euros.toFixed(2) + ' EUR'
 }
 
 function statutVariant(statut: StatutBillet): 'outline' | 'default' | 'secondary' | 'destructive' {
@@ -107,7 +104,7 @@ export default async function BilletsPage({ params }: Props) {
                       {t('fields.payeurNom')}
                     </TableHead>
                     <TableHead className="text-xs uppercase tracking-wider text-muted-foreground">
-                      Passagers
+                      {t('sections.passagers')}
                     </TableHead>
                     <TableHead className="text-xs uppercase tracking-wider text-muted-foreground">
                       {t('fields.montantTtc')}

--- a/app/[locale]/admin/sessions/page.tsx
+++ b/app/[locale]/admin/sessions/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server'
 import { basePrisma } from '@/lib/db/base'
+import { formatDateTimeFr } from '@/lib/format'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Table,
@@ -21,10 +22,6 @@ export default async function AdminSessionsPage() {
     },
     orderBy: { createdAt: 'desc' },
   })
-
-  function formatDate(date: Date): string {
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   function truncateUA(ua: string | null): string {
     if (!ua) return '--'
@@ -66,8 +63,8 @@ export default async function AdminSessionsPage() {
                     <TableCell className="text-xs max-w-48 truncate">
                       {truncateUA(session.userAgent)}
                     </TableCell>
-                    <TableCell className="text-xs">{formatDate(session.createdAt)}</TableCell>
-                    <TableCell className="text-xs">{formatDate(session.expiresAt)}</TableCell>
+                    <TableCell className="text-xs">{formatDateTimeFr(session.createdAt)}</TableCell>
+                    <TableCell className="text-xs">{formatDateTimeFr(session.expiresAt)}</TableCell>
                     <TableCell>
                       <RevokeSessionButton sessionId={session.id} />
                     </TableCell>

--- a/app/[locale]/admin/users/page.tsx
+++ b/app/[locale]/admin/users/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server'
 import { basePrisma } from '@/lib/db/base'
+import { formatDateTimeFr } from '@/lib/format'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Table,
@@ -31,11 +32,6 @@ export default async function AdminUsersPage() {
     select: { userId: true, createdAt: true },
   })
   const lastLoginMap = new Map(latestSessions.map((s) => [s.userId, s.createdAt]))
-
-  function formatDate(date: Date | null): string {
-    if (!date) return '--'
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   return (
     <div className="space-y-6">
@@ -75,7 +71,7 @@ export default async function AdminUsersPage() {
                     </TableCell>
                     <TableCell>{user.exploitant.name}</TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {formatDate(lastLoginMap.get(user.id) ?? null)}
+                      {formatDateTimeFr(lastLoginMap.get(user.id) ?? null)}
                     </TableCell>
                     <TableCell>
                       {user.banned ? (

--- a/lib/actions/billet.ts
+++ b/lib/actions/billet.ts
@@ -38,17 +38,11 @@ async function nextSequence(exploitantId: string, year: number): Promise<number>
   return first.lastSeq
 }
 
-function extractBilletData(formData: FormData) {
-  const passagersJson = formData.get('passagers')
-  let passagers: unknown[] = []
-  if (typeof passagersJson === 'string') {
-    try {
-      passagers = JSON.parse(passagersJson)
-    } catch {
-      passagers = []
-    }
-  }
+type ExtractBilletResult =
+  | { ok: true; data: ReturnType<typeof buildBilletData> }
+  | { ok: false; error: string }
 
+function buildBilletData(formData: FormData, passagers: unknown[]) {
   return {
     typePlannif: formData.get('typePlannif'),
     dateVolDeb: formData.get('dateVolDeb') || undefined,
@@ -80,6 +74,19 @@ function extractBilletData(formData: FormData) {
   }
 }
 
+function extractBilletData(formData: FormData): ExtractBilletResult {
+  const passagersJson = formData.get('passagers')
+  let passagers: unknown[] = []
+  if (typeof passagersJson === 'string' && passagersJson.length > 0) {
+    try {
+      passagers = JSON.parse(passagersJson)
+    } catch {
+      return { ok: false, error: 'Liste des passagers invalide' }
+    }
+  }
+  return { ok: true, data: buildBilletData(formData, passagers) }
+}
+
 export async function createBillet(
   locale: string,
   formData: FormData,
@@ -88,8 +95,9 @@ export async function createBillet(
     requireRole('ADMIN_CALPAX', 'GERANT')
     const ctx = getContext()
 
-    const raw = extractBilletData(formData)
-    const result = billetCreateSchema.safeParse(raw)
+    const extracted = extractBilletData(formData)
+    if (!extracted.ok) return { error: extracted.error }
+    const result = billetCreateSchema.safeParse(extracted.data)
     if (!result.success) {
       return { error: formatZodError(result.error) }
     }
@@ -130,8 +138,9 @@ export async function updateBillet(
     requireRole('ADMIN_CALPAX', 'GERANT')
     const ctx = getContext()
 
-    const raw = extractBilletData(formData)
-    const result = billetCreateSchema.safeParse(raw)
+    const extracted = extractBilletData(formData)
+    if (!extracted.ok) return { error: extracted.error }
+    const result = billetCreateSchema.safeParse(extracted.data)
     if (!result.success) {
       return { error: formatZodError(result.error) }
     }

--- a/lib/actions/tag.ts
+++ b/lib/actions/tag.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '@/lib/auth/requireAuth'
 import { requireRole } from '@/lib/auth/requireRole'
 import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
+import { basePrisma } from '@/lib/db/base'
 
 export async function createTag(formData: FormData): Promise<{ error?: string }> {
   return requireAuth(async () => {
@@ -50,7 +51,6 @@ export async function addTagToBillet(billetId: string, tagId: string): Promise<{
     if (!(await assertBothInTenant(billetId, tagId))) {
       return { error: 'Billet ou tag introuvable' }
     }
-    const { basePrisma } = await import('@/lib/db/base')
     try {
       await basePrisma.billetTag.create({ data: { billetId, tagId } })
     } catch {
@@ -70,7 +70,6 @@ export async function removeTagFromBillet(
     if (!(await assertBothInTenant(billetId, tagId))) {
       return { error: 'Billet ou tag introuvable' }
     }
-    const { basePrisma } = await import('@/lib/db/base')
     await basePrisma.billetTag.delete({
       where: { billetId_tagId: { billetId, tagId } },
     })

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -36,3 +36,12 @@ export function formatDateTimeShort(date: Date, locale: string): string {
     minute: '2-digit',
   })
 }
+
+export function formatDateTimeFr(date: Date | null | undefined, fallback = '--'): string {
+  if (!date) return fallback
+  return new Date(date).toLocaleString('fr-FR')
+}
+
+export function formatEuros(euros: number): string {
+  return euros.toFixed(2) + ' EUR'
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -588,6 +588,8 @@
       "poids": "Weight (kg)",
       "pmr": "PRM"
     },
+    "pmrYes": "Yes",
+    "pmrNo": "No",
     "addRow": "Add passenger",
     "removeRow": "Remove passenger"
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -588,6 +588,8 @@
       "poids": "Poids (kg)",
       "pmr": "PMR"
     },
+    "pmrYes": "Oui",
+    "pmrNo": "Non",
     "addRow": "Ajouter un passager",
     "removeRow": "Supprimer le passager"
   },


### PR DESCRIPTION
## Summary

Pass over the codebase with three lenses (simplify, code review, security/GDPR) and surface concrete fixes that take <30 min each. Findings filtered to the highest-signal items; non-issues documented in the verification notes below.

### Simplification

- **Dedupe formatters.** Extract `formatDateTimeFr()` and `formatEuros()` to `lib/format.ts` and remove four inline copies in `app/[locale]/admin/users/page.tsx`, `app/[locale]/admin/sessions/page.tsx`, `app/[locale]/(app)/billets/page.tsx`, and `app/[locale]/(app)/billets/[id]/page.tsx`.
- **Static `basePrisma` import in `lib/actions/tag.ts`.** The two call sites used `await import('@/lib/db/base')` dynamically, which was inconsistent with `lib/actions/billet.ts` and added no value: ESLint only restricts `adminDb`, not `basePrisma` (`eslint.config.mjs:44-49`).

### Code quality

- **Don't swallow JSON parse errors in `lib/actions/billet.ts:extractBilletData`.** A malformed `passagers` payload was silently coerced to `[]`, hiding the real cause behind a generic "Au moins un passager requis" zod error. The function now returns a discriminated `{ ok: true, data } | { ok: false, error }` and `createBillet` / `updateBillet` propagate the explicit "Liste des passagers invalide" message.

### UX / i18n

- **Hardcoded FR strings in `app/[locale]/(app)/billets/[id]/page.tsx`** ("Payeur", "Planification", "Passagers", "Oui", "Non") replaced with translation keys. The `billets.sections.*` keys already existed; `pmrYes` / `pmrNo` added under `passagers` namespace in both `messages/fr.json` and `messages/en.json`.
- **`app/[locale]/(app)/billets/page.tsx`** had a hardcoded "Passagers" column header — switched to `t('sections.passagers')`.

### Security / GDPR — verification notes (no changes)

Spot-checked items that came up during the pass; everything below is in good shape:

- **Cron auth** — `lib/auth/cron.ts:81-88` already uses `timingSafeEqual` with a length-prefix short-circuit, plus per-endpoint cooldown (`cron_invocation` table). All four cron routes call `verifyCronRequest`.
- **2FA TOTP** — Better Auth plugin wiring in place via `components/auth/two-factor-card.tsx` (#79).
- **Passenger weight encryption** — `mapPassagerForCreate` in `lib/actions/billet.ts:15-26` writes `poidsEncrypted` only; `safeDecryptInt` is used at read sites.
- **Fiche-vol PDF** — `app/api/vols/[id]/fiche-vol/route.ts` already enforces `requireRole('ADMIN_CALPAX', 'GERANT', 'PILOTE')`, applies `buildVolWhereForRole` for tenant + pilot scoping, and returns `Cache-Control: private, no-store, no-cache, must-revalidate`. I considered a per-user/per-vol rate-limit but decided against it: there's no shared store today, an authenticated admin can already trigger the work freely, and adding a new DB table or in-memory cache is out of scope for a review pass.
- **`lib/actions/paiement.ts` Decimal coercion** (`Number(billet.montantTtc)`): real precision loss only above 2^53 cents (~90 trillion EUR). Not actionable for hot-air balloon ticket amounts.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — only pre-existing warnings (unrelated `<img>` and unused-var hints)
- [x] `pnpm test` — 17 files / 143 tests pass
- [ ] Visually verify billet detail page renders section titles + Yes/No correctly in both FR and EN
- [ ] Verify admin/users and admin/sessions still show the same date format ("dd/mm/yyyy hh:mm:ss")
- [ ] Submit a billet form with a corrupted `passagers` field via devtools → expect "Liste des passagers invalide"

## Out of scope

- Mobile responsiveness sweep across remaining forms (continuation of #88/#93).
- Decimal/money refactor to use `Prisma.Decimal` end-to-end.
- Audit-log redaction completeness check on encrypted column writes — flagged for a follow-up issue.

https://claude.ai/code/session_01ATzrCSDFSCYCzxkUsiFHhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATzrCSDFSCYCzxkUsiFHhn)_