### PR TITLE
review: secure impersonation cookie + dedupe audit formatters + 2FA a11y

### DIFF
--- a/app/[locale]/(app)/audit/audit-client.tsx
+++ b/app/[locale]/(app)/audit/audit-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import {
   Table,
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
 import { fetchAuditLogs } from '@/lib/actions/audit'
+import { formatAuditValue, formatDateTimeShort } from '@/lib/format'
 
 const ENTITY_TYPES = ['Ballon', 'Pilote', 'Billet', 'Passager', 'Paiement', 'Vol', 'AUTH']
 const ACTIONS = [
@@ -40,6 +41,7 @@ type AuditLog = {
 
 export function AuditClient() {
   const t = useTranslations('audit')
+  const locale = useLocale()
   const [entityType, setEntityType] = useState('')
   const [action, setAction] = useState('')
   const [page, setPage] = useState(1)
@@ -62,16 +64,6 @@ export function AuditClient() {
     void load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entityType, action, page])
-
-  function formatDate(date: Date) {
-    return new Date(date).toLocaleString('fr-FR')
-  }
-
-  function formatJson(value: unknown): string {
-    if (value === null || value === undefined) return '—'
-    if (typeof value === 'string') return value
-    return JSON.stringify(value)
-  }
 
   return (
     <div className="space-y-4">
@@ -136,7 +128,9 @@ export function AuditClient() {
           <TableBody>
             {logs.map((log) => (
               <TableRow key={String(log.id)}>
-                <TableCell className="text-xs">{formatDate(log.createdAt)}</TableCell>
+                <TableCell className="text-xs">
+                  {formatDateTimeShort(log.createdAt, locale)}
+                </TableCell>
                 <TableCell>
                   <Badge variant="outline">{log.entityType}</Badge>{' '}
                   <span className="text-xs text-muted-foreground">{log.entityId.slice(0, 8)}</span>
@@ -146,10 +140,10 @@ export function AuditClient() {
                 </TableCell>
                 <TableCell>{log.field ?? '—'}</TableCell>
                 <TableCell className="max-w-32 truncate text-xs">
-                  {formatJson(log.beforeValue)}
+                  {formatAuditValue(log.beforeValue)}
                 </TableCell>
                 <TableCell className="max-w-32 truncate text-xs">
-                  {formatJson(log.afterValue)}
+                  {formatAuditValue(log.afterValue)}
                 </TableCell>
               </TableRow>
             ))}

--- a/app/[locale]/admin/audit/audit-client.tsx
+++ b/app/[locale]/admin/audit/audit-client.tsx
@@ -15,7 +15,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { fetchAdminAuditLogs } from '@/lib/actions/admin'
-import { formatDateTimeShort } from '@/lib/format'
+import { formatAuditValue, formatDateTimeShort } from '@/lib/format'
 
 const ENTITY_TYPES = ['Ballon', 'Pilote', 'Billet', 'Passager', 'Paiement', 'Vol', 'Exploitant']
 const ACTIONS = [
@@ -97,12 +97,6 @@ export function AdminAuditClient({
       cancelled = true
     }
   }, [exploitantId, entityType, action, page])
-
-  function formatJson(value: unknown): string {
-    if (value === null || value === undefined) return '—'
-    if (typeof value === 'string') return value
-    return JSON.stringify(value)
-  }
 
   /** True for UPDATE rows where the audit-extension recorded a single field
    *  change (one row per modified field). For these we render the before /
@@ -241,24 +235,24 @@ export function AdminAuditClient({
                     <TableCell colSpan={2} className="text-xs">
                       <div className="flex items-center gap-2 font-mono">
                         <span className="rounded bg-red-50 px-1.5 py-0.5 text-red-700 line-through">
-                          {formatJson(log.beforeValue)}
+                          {formatAuditValue(log.beforeValue)}
                         </span>
                         <ArrowRight
                           className="h-3 w-3 shrink-0 text-muted-foreground"
                           aria-hidden
                         />
                         <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-emerald-700">
-                          {formatJson(log.afterValue)}
+                          {formatAuditValue(log.afterValue)}
                         </span>
                       </div>
                     </TableCell>
                   ) : (
                     <>
                       <TableCell className="max-w-32 truncate text-xs">
-                        {formatJson(log.beforeValue)}
+                        {formatAuditValue(log.beforeValue)}
                       </TableCell>
                       <TableCell className="max-w-32 truncate text-xs">
-                        {formatJson(log.afterValue)}
+                        {formatAuditValue(log.afterValue)}
                       </TableCell>
                     </>
                   )}

--- a/app/[locale]/admin/sessions/page.tsx
+++ b/app/[locale]/admin/sessions/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from 'next-intl/server'
+import { getLocale, getTranslations } from 'next-intl/server'
 import { basePrisma } from '@/lib/db/base'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -9,10 +9,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { formatDateTimeShort } from '@/lib/format'
 import { RevokeSessionButton } from './revoke-button'
 
 export default async function AdminSessionsPage() {
   const t = await getTranslations('admin.sessions')
+  const locale = await getLocale()
 
   const sessions = await basePrisma.session.findMany({
     where: { expiresAt: { gt: new Date() } },
@@ -21,10 +23,6 @@ export default async function AdminSessionsPage() {
     },
     orderBy: { createdAt: 'desc' },
   })
-
-  function formatDate(date: Date): string {
-    return new Date(date).toLocaleString('fr-FR')
-  }
 
   function truncateUA(ua: string | null): string {
     if (!ua) return '--'
@@ -66,8 +64,12 @@ export default async function AdminSessionsPage() {
                     <TableCell className="text-xs max-w-48 truncate">
                       {truncateUA(session.userAgent)}
                     </TableCell>
-                    <TableCell className="text-xs">{formatDate(session.createdAt)}</TableCell>
-                    <TableCell className="text-xs">{formatDate(session.expiresAt)}</TableCell>
+                    <TableCell className="text-xs">
+                      {formatDateTimeShort(session.createdAt, locale)}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {formatDateTimeShort(session.expiresAt, locale)}
+                    </TableCell>
                     <TableCell>
                       <RevokeSessionButton sessionId={session.id} />
                     </TableCell>

--- a/app/[locale]/admin/users/page.tsx
+++ b/app/[locale]/admin/users/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from 'next-intl/server'
+import { getLocale, getTranslations } from 'next-intl/server'
 import { basePrisma } from '@/lib/db/base'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -10,10 +10,12 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
+import { formatDateTimeShort } from '@/lib/format'
 import { UserBanButton } from './user-ban-button'
 
 export default async function AdminUsersPage() {
   const t = await getTranslations('admin.users')
+  const locale = await getLocale()
 
   const users = await basePrisma.user.findMany({
     include: {
@@ -32,9 +34,9 @@ export default async function AdminUsersPage() {
   })
   const lastLoginMap = new Map(latestSessions.map((s) => [s.userId, s.createdAt]))
 
-  function formatDate(date: Date | null): string {
+  function formatLastLogin(date: Date | null): string {
     if (!date) return '--'
-    return new Date(date).toLocaleString('fr-FR')
+    return formatDateTimeShort(date, locale)
   }
 
   return (
@@ -75,7 +77,7 @@ export default async function AdminUsersPage() {
                     </TableCell>
                     <TableCell>{user.exploitant.name}</TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {formatDate(lastLoginMap.get(user.id) ?? null)}
+                      {formatLastLogin(lastLoginMap.get(user.id) ?? null)}
                     </TableCell>
                     <TableCell>
                       {user.banned ? (

--- a/components/auth/two-factor-card.tsx
+++ b/components/auth/two-factor-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import QRCode from 'qrcode'
@@ -32,6 +32,16 @@ export function TwoFactorCard({ enabled }: Props) {
   const [code, setCode] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Live-region announcement for backup-code copy success. Sonner toasts are
+  // visual-only on most setups, so screen reader users wouldn't otherwise
+  // learn that the codes landed in the clipboard.
+  const [copyAnnouncement, setCopyAnnouncement] = useState('')
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    }
+  }, [])
 
   async function handleEnable(e: React.FormEvent) {
     e.preventDefault()
@@ -101,6 +111,10 @@ export function TwoFactorCard({ enabled }: Props) {
     const text = codes.join('\n')
     navigator.clipboard.writeText(text)
     toast.success(t('backupCodesCopied'))
+    // Re-set on each click so consecutive copies still announce.
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    setCopyAnnouncement(t('backupCodesCopied'))
+    copyTimerRef.current = setTimeout(() => setCopyAnnouncement(''), 4000)
   }
 
   return (
@@ -176,6 +190,9 @@ export function TwoFactorCard({ enabled }: Props) {
               >
                 {t('copyBackupCodes')}
               </Button>
+              <div role="status" aria-live="polite" className="sr-only">
+                {copyAnnouncement}
+              </div>
             </div>
 
             <form onSubmit={handleVerify} className="space-y-3">

--- a/lib/actions/tag.ts
+++ b/lib/actions/tag.ts
@@ -1,10 +1,20 @@
 'use server'
 
+import { Prisma } from '@prisma/client'
 import { revalidatePath } from 'next/cache'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { requireRole } from '@/lib/auth/requireRole'
 import { getContext } from '@/lib/context'
 import { db } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+// Prisma unique-constraint violation — used to distinguish "duplicate" from
+// real failures so we don't show the user a misleading message.
+const UNIQUE_VIOLATION = 'P2002'
+
+function isUniqueViolation(err: unknown): boolean {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === UNIQUE_VIOLATION
+}
 
 export async function createTag(formData: FormData): Promise<{ error?: string }> {
   return requireAuth(async () => {
@@ -16,8 +26,12 @@ export async function createTag(formData: FormData): Promise<{ error?: string }>
 
     try {
       await db.tag.create({ data: { nom: nom.trim(), couleur, exploitantId: ctx.exploitantId } })
-    } catch {
-      return { error: 'Un tag avec ce nom existe déjà' }
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        return { error: 'Un tag avec ce nom existe déjà' }
+      }
+      logger.error({ err, exploitantId: ctx.exploitantId }, 'createTag: unexpected failure')
+      return { error: 'Erreur lors de la création du tag' }
     }
     revalidatePath('/settings')
     return {}
@@ -53,8 +67,12 @@ export async function addTagToBillet(billetId: string, tagId: string): Promise<{
     const { basePrisma } = await import('@/lib/db/base')
     try {
       await basePrisma.billetTag.create({ data: { billetId, tagId } })
-    } catch {
-      return { error: 'Tag déjà assigné' }
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        return { error: 'Tag déjà assigné' }
+      }
+      logger.error({ err, billetId, tagId }, 'addTagToBillet: unexpected failure')
+      return { error: "Erreur lors de l'ajout du tag" }
     }
     revalidatePath(`/billets/${billetId}`)
     return {}

--- a/lib/admin/impersonation-actions.ts
+++ b/lib/admin/impersonation-actions.ts
@@ -47,9 +47,13 @@ export async function startImpersonation(
   const targetName = `${target.name} (${target.frDecNumber})`
   const cookieValue = signImpersonationCookie(adminUserId, targetExploitantId, targetName)
   const store = await cookies()
+  // `secure: true` always — the impersonation cookie carries the privilege
+  // claim used by `requireAuth`, so HTTP transit is unacceptable even on
+  // localhost. Better Auth dev sessions cope; only impersonation tooling has
+  // to be exercised over HTTPS in development.
   store.set(IMPERSONATION_COOKIE_NAME, cookieValue, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure: true,
     sameSite: 'lax',
     path: '/',
     maxAge: IMPERSONATION_TTL_MS / 1000,

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -36,3 +36,15 @@ export function formatDateTimeShort(date: Date, locale: string): string {
     minute: '2-digit',
   })
 }
+
+/**
+ * Render a value pulled from an audit-log JSON column for display in a table
+ * cell. Strings are returned verbatim; null/undefined become an em-dash;
+ * everything else (numbers, booleans, objects, arrays, `[REDACTED]` markers)
+ * is JSON-serialized so it stays inspectable but renders as a single line.
+ */
+export function formatAuditValue(value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}

--- a/tests/unit/format.spec.ts
+++ b/tests/unit/format.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { formatAuditValue } from '@/lib/format'
+
+describe('formatAuditValue', () => {
+  it('renders null and undefined as an em-dash', () => {
+    expect(formatAuditValue(null)).toBe('—')
+    expect(formatAuditValue(undefined)).toBe('—')
+  })
+
+  it('returns strings unchanged so the [REDACTED] marker stays readable', () => {
+    expect(formatAuditValue('[REDACTED]')).toBe('[REDACTED]')
+    expect(formatAuditValue('Cameron Balloons')).toBe('Cameron Balloons')
+    expect(formatAuditValue('')).toBe('')
+  })
+
+  it('JSON-encodes scalars and complex values onto a single line', () => {
+    expect(formatAuditValue(42)).toBe('42')
+    expect(formatAuditValue(true)).toBe('true')
+    expect(formatAuditValue(false)).toBe('false')
+    expect(formatAuditValue(['A', 'B'])).toBe('["A","B"]')
+    expect(formatAuditValue({ a: 1 })).toBe('{"a":1}')
+  })
+})


### PR DESCRIPTION
Pass over recent merges (impersonation #59, 2FA #15, audit-diff UI #94, mobile-responsive #88) covering simplification, code quality, security/GDPR and UX. Each finding was verified against the actual code before changing anything — this PR keeps only the high-confidence, high-impact fixes. The rest of the audit is recorded below for follow-up issues.

## Summary

- **Security**: impersonation cookie is now `secure: true` always — previously gated on `NODE_ENV === 'production'`, leaving the HMAC-signed privilege claim exposed over HTTP in dev environments.
- **Quality**: `lib/actions/tag.ts` no longer swallows Prisma errors with empty `catch {}`. The friendly "already exists / already assigned" message is now reserved for actual `P2002` unique-violations; everything else is logged via `pino` so monitoring catches real failures.
- **Simplify**: `formatAuditValue` extracted into `lib/format.ts`; both audit clients (admin + tenant) drop their inline duplicate.
- **Quality / i18n**: hardcoded `new Date().toLocaleString('fr-FR')` in `admin/users`, `admin/sessions` and the user audit client replaced by `formatDateTimeShort(date, locale)` so EN users stop seeing French timestamps.
- **A11y**: 2FA backup-codes copy now also pushes to an `aria-live="polite"` sr-only region — sonner toasts are visual-only on most setups, so screen reader users were getting no confirmation that the codes hit the clipboard.
- **Tests**: unit coverage for `formatAuditValue` (null / undefined → em-dash, strings preserved including `[REDACTED]`, scalars + objects JSON-serialized).

## Review notes — claims dropped after verification

These came up in the audit but did **not** justify changes:

- *"Audit log diff colors fail WCAG AA"* — `text-red-700` on `bg-red-50` is ≈6.16:1, `text-emerald-700` on `bg-emerald-50` ≈5.86:1. Both pass AA for normal text.
- *"tag.ts has a tenant isolation breach via basePrisma"* — `assertBothInTenant` uses `db` (tenant-scoped), so cross-tenant ids return `null` and the join row is never created. The empty catch block was the real bug, fixed here.
- *"Impersonation cookie leaks `targetName` (CRITICAL)"* — cookie is `httpOnly` + HMAC-signed and bound to `adminUserId`. XSS can't read it; if it's stolen the attacker has the session anyway. Encrypting the name would only force a DB lookup on every request without changing the threat model.

## Follow-ups (not in this PR)

Worth filing as separate issues:

- `ENTITY_TYPES` / `ACTIONS` arrays in audit clients are hand-maintained enums that drift silently from the Prisma schema.
- Audit log table has no horizontal-scroll affordance on mobile (8 columns).
- `messages/fr.json` vs `messages/en.json` lack a CI parity check; orphaned keys would surface as "missing translation" warnings only at runtime.
- Empty catch blocks in `lib/actions/billet.ts:47` (similar pattern, not touched here to keep the diff focused).
- `REDACT_FIELDS` in `lib/db/audit-extension.ts` doesn't list pilot email/phone — worth confirming whether pilot rows ever go through audit before adding.

## Test plan

- [x] `pnpm typecheck` (clean)
- [x] `pnpm lint` (no new warnings)
- [x] `pnpm test` — 146/146 incl. new `format.spec.ts`
- [ ] Manual: trigger an impersonation in a dev environment served over HTTP and confirm the cookie is rejected (expected — `secure: true` blocks non-HTTPS).
- [ ] Manual: copy 2FA backup codes with VoiceOver / NVDA and confirm the announcement is read.
- [ ] Manual: open `admin/users` with `?locale=en` and confirm the last-login column renders an English-format timestamp.

https://claude.ai/code/session_01U1fUTEuBZ8Wv3JMj31VPQn

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1fUTEuBZ8Wv3JMj31VPQn)_